### PR TITLE
Change ZRD to new url

### DIFF
--- a/custom_components/afvalwijzer/const/const.py
+++ b/custom_components/afvalwijzer/const/const.py
@@ -52,7 +52,7 @@ SENSOR_COLLECTORS_OPZET = {
     "venray": "https://afvalkalender.venray.nl",
     "voorschoten": "https://afvalkalender.voorschoten.nl",
     "waalre": "https://afvalkalender.waalre.nl",
-    "zrd": "https://afvalkalender.zrd.nl",
+    "zrd": "https://www.zrd.nl",
 }
 
 SENSOR_COLLECTORS_ICALENDAR = {


### PR DESCRIPTION
ZRD changed their API url. For the Opzet integration to work with ZRD the url needs to be updated.