### PR TITLE
Update README.md correct images paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ automation:
 
 ***
 
-[exampleimg1]: afvalwijzer-lovelace.png
-[exampleimg2]: afvalwijzer_lovelace.png
+[exampleimg1]: images/afvalwijzer-lovelace_2.png
+[exampleimg2]: images/afvalwijzer_lovelace_1.png
 [customupdater]: https://github.com/custom-components/custom_updater
 [customupdaterbadge]: https://img.shields.io/badge/custom__updater-true-success.svg


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the image paths for two example images used in the documentation.

Changes in `automation:` in file `README.md`:

* Updated the paths for `exampleimg1` and `exampleimg2` to point to new locations in the `images` directory. (`[README.mdL237-R238](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L237-R238)`)In 2b297e72d4e4bf5c4d8ce8ca3b0bc3fd098f63bc the images where moved to the `images` folder.