### PR TITLE
Added support for Saver

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ _Component to integrate with the following providers._
 | peelenmaas                       |
 | prezero                          |
 | purmerend                        |
+| saver                            |
 | rad                              |
 | reinis                           |
 | rd4                              |

--- a/custom_components/afvalwijzer/const/const.py
+++ b/custom_components/afvalwijzer/const/const.py
@@ -46,6 +46,7 @@ SENSOR_COLLECTORS_OPZET = {
     "peelenmaas": "https://afvalkalender.peelenmaas.nl",
     "prezero": "https://inzamelwijzer.prezero.nl",
     "purmerend": "https://afvalkalender.purmerend.nl",
+    "saver": "https://saver.nl",
     "schouwen-duiveland": "https://afvalkalender.schouwen-duiveland.nl",
     "spaarnelanden": "https://afvalwijzer.spaarnelanden.nl",
     "sudwestfryslan": "https://afvalkalender.sudwestfryslan.nl",


### PR DESCRIPTION
Saver is transitioning to Opzet, so I have added the Saver url to the Opzet provider list and updated the README. Attempts to fix: #326, #336

⚠️ There is still a problem on my side. Only some requests seem to work. They are all hitting the same URL, eg: https://saver.nl/rest/adressen/4611AR-4, but it looks like most of them are getting blocked. I don't see anything in the logs, so maybe someone can check this at their side? It works sometimes, and I have _a few_ sensors reporting data after a while.