### PR TITLE
Add gemeente Uithoorn as part of Kliko Groep

### DIFF
--- a/custom_components/afvalwijzer/const/const.py
+++ b/custom_components/afvalwijzer/const/const.py
@@ -63,6 +63,10 @@ SENSOR_COLLECTORS_KLIKOGROEP = {
     "oudeijsselstreek": {
         "url": "https://cp-oudeijsselstreek.klikocontainermanager.com/MyKliko",
         "app": "cp-oudeijsselstreek.kcm.com"
+    },
+    "uithoorn": {
+        "url": "https://cp-uithoorn.klikocontainermanager.com/MyKliko",
+        "app": "cp-uithoorn.kcm.com"
     }
 }
 


### PR DESCRIPTION
Municipality, gemeente, Uithoorn started to use Kliko Groep as their waist disposal company. This was much like the existing oudeijsselstreek integration. I have added the details for Gemeente Uithoorn to the SENSOR_COLLECTORS_KLIKOGROEP in the same way and this seems to work OK for me after restart, I can add the sensors for Uithoorn to my dashboard.