### PR TITLE
Bugfix for burgerportaal not selecting address with suffix

### DIFF
--- a/custom_components/afvalwijzer/collector/burgerportaal.py
+++ b/custom_components/afvalwijzer/collector/burgerportaal.py
@@ -70,14 +70,18 @@ def get_waste_data_raw(
             return
         
         address_id = None
-        for item in raw_response:
-           if item.get('addition').casefold() == suffix.casefold():
-              address_id = item['addressId']
-              break
-          
+
+        if suffix:
+            for item in raw_response:
+                addition = item.get('addition')
+                if addition and addition.casefold() == suffix.casefold():
+                    address_id = item['addressId']
+                    break
+        
         if not address_id:
-            _LOGGER.error('Address not found!')
-            return
+            address_id = raw_response[0]['addressId']
+            _LOGGER.warning('Address not found!')
+            
     except requests.exceptions.RequestException as err:
         raise ValueError(err) from err
 


### PR DESCRIPTION
There is a bug in the burgerportaal code. By default, it selects the first available address without considering the suffix. In some cases, there is no waste calendar available for the first available address (generally the one without suffix), but there is for another address (including suffix).
For example: in Groningen, ground floor (no suffix) is often a commercial address (for example a shop), which has no waste calendar. The residential address on other floors do have a calendar. In that case the it's important to select the right suffix.
In summary: In burgerportaal there can be a difference in the calendars in between suffixes, which is why it's important to match the right suffix.

Example postal code to test:
9712NC, numbers 5 (empty calendar) and 5-A (normal calendar).
Using this url: https://21burgerportaal.mendixcloud.com/p/groningen/landing/