### PR TITLE
Update burgerportaal.py

### DIFF
--- a/custom_components/afvalwijzer/collector/burgerportaal.py
+++ b/custom_components/afvalwijzer/collector/burgerportaal.py
@@ -77,9 +77,10 @@ def get_waste_data_raw(
                 if addition and addition.casefold() == suffix.casefold():
                     address_id = item['addressId']
                     break
+        else:
+            address_id = raw_response[0]['addressId']
         
         if not address_id:
-            address_id = raw_response[0]['addressId']
             _LOGGER.warning('Address not found!')
             
     except requests.exceptions.RequestException as err:


### PR DESCRIPTION
Preventing unnecessary logging when suffix address is not found.

Only show message when no address is found

Fixes #429 