### PR TITLE
Allow reconfiguring the integration

### DIFF
--- a/custom_components/afvalwijzer/config_flow.py
+++ b/custom_components/afvalwijzer/config_flow.py
@@ -48,7 +48,8 @@ all_collectors_tagged = (
     [(collector, True) for collector in SENSOR_COLLECTORS_RD4.keys()] +  # Primary
     [(collector, True) for collector in SENSOR_COLLECTORS_ROVA.keys()] +  # Primary
     [(collector, True) for collector in SENSOR_COLLECTORS_XIMMIO_IDS.keys()] +  # Primary
-    [("rwm", True)]  # Primary
+    [("rwm", True)] +  # Primary
+    [("", False)]  # Secondary
 )
 
 # Extract primary collectors (where tag is True)

--- a/custom_components/afvalwijzer/translations/en.json
+++ b/custom_components/afvalwijzer/translations/en.json
@@ -41,7 +41,8 @@
       "invalid_street_number": "Street number must be numeric"
     },
     "abort": {
-      "already_configured": "Afvalwijzer is already configured"
+      "already_configured": "Afvalwijzer is already configured",
+      "reconfigure_successful": "Re-configuration was successful"
     }
   },
   "options": {

--- a/custom_components/afvalwijzer/translations/nl.json
+++ b/custom_components/afvalwijzer/translations/nl.json
@@ -41,7 +41,8 @@
       "invalid_street_number": "Huisnummer moet numeriek zijn"
     },
     "abort": {
-      "already_configured": "Afvalwijzer is al geconfigureerd"
+      "already_configured": "Afvalwijzer is al geconfigureerd",
+      "reconfigure_successful": "Afvalwijzer is geconfigureerd"
     }
   },
   "options": {


### PR DESCRIPTION
I wanted to adjust the time settings and keep my name overrides, this was not possible yet so I added the reconfigure step.

https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#reconfigure

It can be accessed through the overflow menu 

<img width="2412" height="1478" alt="image" src="https://github.com/user-attachments/assets/1afc9679-ab01-4b3c-b1cd-53473efcea51" />

It also remembers the previous values 
<img width="1042" height="1760" alt="image" src="https://github.com/user-attachments/assets/41598a61-7f4d-467f-bf99-437c8c5037d2" />

