### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/afvalwijzer/sensor.py
+++ b/custom_components/afvalwijzer/sensor.py
@@ -49,8 +49,10 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up sensors using the platform schema."""
     if not discovery_info:
-        _LOGGER.error(
-            "No discovery information provided; sensors cannot be created.")
+        if hass.is_running:
+            _LOGGER.warning(
+                "No discovery information provided; sensors cannot be created."
+            )
         return
 
     await _setup_sensors(hass, discovery_info, async_add_entities)


### PR DESCRIPTION
On the initial run of the integration, Home Assistant logs a warning: 
> No discovery information provided; sensors cannot be created

This is **expected behavior**, since the integration setup is not yet completed and `discovery_info` is not available during the very first load.

## Fix

This PR suppresses the warning during startup by checking `hass.is_running`.

- **First run**: no log is shown (since this is normal).  
- **Reloads / runtime errors**: the warning is still logged, so real issues remain visible.

## Notes

- Prevents false-positive warnings on first startup.  
- Likely fixes #440.