### PR TITLE
Remove pip from Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,11 +5,3 @@ updates:
       directory: '/'
       schedule:
           interval: 'weekly'
-
-    - package-ecosystem: 'pip'
-      directory: '/'
-      schedule:
-          interval: 'weekly'
-      ignore:
-          # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
-          - dependency-name: 'homeassistant'


### PR DESCRIPTION
requirements.txt contains unpinned packages so Dependabot will never bump those