### PR TITLE
Update API endpoint for fetching notifications

### DIFF
--- a/custom_components/afvalwijzer/collector/opzet.py
+++ b/custom_components/afvalwijzer/collector/opzet.py
@@ -163,7 +163,7 @@ def _fetch_notification_data_raw_temp(
     verify: bool,
 ) -> list[dict[str, Any]]:
     """Fetch raw notification data from the API."""
-    url_notification = f"{base_url}/api/meldingen/{bag_id}/App"
+    url_notification = f"{base_url}/rest/app/meldingen/{bag_id}"
     response = session.get(url_notification, timeout=timeout, verify=verify)
     response.raise_for_status()
     data = response.json()


### PR DESCRIPTION
Tested with:

| Provider | Testresult |
|----------|------------|
Afval3xBeter | OK (response = `[]`)
afvalstoffendienst | OK
afvalstoffendienstkalender| OK |
AlphenAanDenRijn | OK
Berkelland |NA (changed to TwenteMilieu)
Cranendonck | OK (response = `[]`)
Cyclus | OK
DAR | OK
DeFryskeMarren | OK
DenHaag | OK (response = `[]`)
GAD | OK
Geertruidenberg | OK (response = `[]`)
HVC | OK (response = `[]`)
Lingewaard | OK
Middelburg-Vlissingen | OK (response = `[]`)
Mijnafvalzaken | OK (response = `[]`)
Montfoort | OK
offalkalinder | OK (response = `[]`)
PeelEnMaas | OK (response = `[]`)
PreZero | OK (response = `[]`)
Purmerend | OK (response = `[]`)
RWM | OK
Saver | OK (response = `[]`)
Schouwen-Duiveland | OK (response = `[]`)
Sliedrecht | OK (response = `[]`)
Spaarnelanden | OK
SudwestFryslan | OK
SUEZ | OK (response = `[]`)
Uithoorn | OK
venray | OK
Voorschoten | OK (response = `[]`)
waalre | OK
ZRD | OK (response = `[]`)