### PR TITLE
Add 'greenbasket' mapping for waste type

### DIFF
--- a/custom_components/afvalwijzer/common/main_functions.py
+++ b/custom_components/afvalwijzer/common/main_functions.py
@@ -42,6 +42,7 @@ WASTE_TYPE_MAPPING: dict[str, str] = {
     "gfte afval": "gft",
     "glass": "glas",
     "green": "gft",
+    "greenbasket": "gft",
     "grey": "restafval",
     "grijze container": "restafval",
     "grijze container / sortibak": "restafval",


### PR DESCRIPTION
Add 'greenbasket' mapping for waste type, UNTESTED. Dit is voor de situatie in Delft centrum/Avalex. Fix voor #592 