### PR TITLE
Fix Today sensor showing 'geen' and handle mixed date types

### DIFF
--- a/custom_components/afvalwijzer/common/day_sensor_data.py
+++ b/custom_components/afvalwijzer/common/day_sensor_data.py
@@ -1,6 +1,6 @@
 """Generate day-based waste sensor data."""
 
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 from homeassistant.util import dt as dt_util
 
@@ -11,15 +11,14 @@ class DaySensorData:
     """Generate day-based waste sensor data."""
 
     def __init__(self, waste_data_formatted, default_label):
-        """Initialize day-based sensor data.
+        """Initialize day-based sensor data."""
 
-        Prepare waste data for today, tomorrow, and the day after tomorrow.
-        """
+        # Sort using string conversion to prevent crashes if types are mixed upstream
         self.waste_data_formatted = sorted(
-            waste_data_formatted, key=lambda d: d["date"]
+            waste_data_formatted, key=lambda d: str(d["date"])
         )
 
-        # Store as proper timezone-aware date objects for Home Assistant calculations
+        # Keep as proper datetime.date objects for HA calculations
         self.today_date = dt_util.now().date()
         self.tomorrow_date = self.today_date + timedelta(days=1)
         self.day_after_tomorrow_date = self.today_date + timedelta(days=2)
@@ -38,31 +37,31 @@ class DaySensorData:
             for waste in self.waste_data_formatted:
                 waste_date = waste["date"]
 
-                if isinstance(waste_date, datetime):
-                    waste_date_obj = waste_date.date()
-                elif isinstance(waste_date, date):
-                    waste_date_obj = waste_date
+                # Scenario 1: It's a datetime or date object (Naive or Timezone-Aware)
+                if hasattr(waste_date, "year") and hasattr(waste_date, "month") and hasattr(waste_date, "day"):
+                    if (waste_date.year == target_date.year and
+                        waste_date.month == target_date.month and
+                        waste_date.day == target_date.day):
+                        day.append(waste["type"])
+
+                # Scenario 2: It's a raw string (e.g., "2026-07-09")
                 elif isinstance(waste_date, str):
                     try:
-                        waste_date_obj = datetime.strptime(waste_date, "%Y-%m-%d").date()
+                        parsed_date = datetime.strptime(waste_date, "%Y-%m-%d").date()
+                        if parsed_date == target_date:
+                            day.append(waste["type"])
                     except ValueError:
-                        continue
-                else:
-                    continue
+                        pass
 
-                # Safe comparison between two date objects
-                if waste_date_obj == target_date:
-                    day.append(waste["type"])
-
-            # Remove duplicates and apply default label if empty
+            # De-duplicate and apply the default label (e.g., "geen") if empty
             waste_types = list(dict.fromkeys(day))
             if not waste_types:
                 waste_types.append(self.default_label)
-
             return waste_types
+
         except Exception as err:
             _LOGGER.error("Error occurred in __gen_day_sensor: %s", err)
-            return []
+            return [self.default_label]
 
     def _gen_day_sensor_data(self):
         """Generate the combined day sensor data dictionary."""

--- a/custom_components/afvalwijzer/common/waste_data_transformer.py
+++ b/custom_components/afvalwijzer/common/waste_data_transformer.py
@@ -118,14 +118,7 @@ class WasteDataTransformer:
             _LOGGER.error("Other error occurred waste_data_formatted: %s", err)
             waste_data_formatted = []
 
-        if self.exclude_pickup_today.casefold() not in ("false", "no"):
-            waste_data_for_days = [
-                w for w in waste_data_formatted if w["date"] > self.DATE_TODAY
-            ]
-        else:
-            waste_data_for_days = waste_data_formatted
-
-        days = DaySensorData(waste_data_for_days, self.default_label)
+        days = DaySensorData(waste_data_formatted, self.default_label)
 
         try:
             waste_data_after_date_selected = [


### PR DESCRIPTION
## Summary
This pull request addresses an issue where the "Today" sensor incorrectly displayed the default label ("geen") instead of the actual waste type scheduled for collection today (e.g., "gft"). Additionally, it incorporates upstream changes to improve robustness when comparing mixed date types.

Fixes #616

## Key Changes
- **Fixed `exclude_pickup_today` logic in `DaySensorData`**: Removed the date filtering condition in `WasteDataTransformer` before generating `DaySensorData`. `DaySensorData` now receives the full, unfiltered dataset so it can correctly generate the "Today" sensor.
## Includes the changes from 1017
I added the changes from 1017 as well to the PR
- **Improved date comparison robustness**: Applied upstream changes to `DaySensorData` that explicitly check for `.year`, `.month`, and `.day` properties to safely compare combinations of strings, naive datetimes, and timezone-aware objects without raising exceptions.
- **Improved sorting logic**: Sorted `waste_data_formatted` by `str(d["date"])` rather than raw `d["date"]` objects to prevent `TypeError` when dealing with mixed data types.

## Why this is needed
When users enabled the `exclude_pickup_today` setting, it correctly filtered today's pickups from the "next" pickup sensors, but it inadvertently completely stripped today's data from being passed into the "Today" sensor. This effectively made the "Today" sensor permanently blank ("geen") under these settings. Furthermore, upstream integrations sometimes produce mixed date formats which caused sorting and comparison logic to crash; the new comparison logic handles these gracefully.
