### PR TITLE
fix: resolve entity ID deprecation warnings for HA 2027.2.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "snyk.advanced.autoSelectOrganization": true,
+    "coderabbit.region": "eu"
+}

--- a/custom_components/afvalwijzer/const/const.py
+++ b/custom_components/afvalwijzer/const/const.py
@@ -168,7 +168,7 @@ CONF_DEFAULT_LABEL = "default_label"
 CONF_EXCLUDE_LIST = "exclude_list"
 CONF_TRANSLATE_STATES = "translate_states"
 
-SENSOR_PREFIX = "afvalwijzer "
+SENSOR_PREFIX = "afvalwijzer_"
 SENSOR_ICON = "mdi:recycle"
 
 ATTR_LAST_UPDATE = "last_update"

--- a/custom_components/afvalwijzer/sensor_custom.py
+++ b/custom_components/afvalwijzer/sensor_custom.py
@@ -13,7 +13,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, slugify
 
 from .const.const import (
     ATTR_DAYS_UNTIL_COLLECTION_DATE,
@@ -109,7 +109,7 @@ class CustomSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
 
         self._attr_has_entity_name = True
         self._attr_translation_key = waste_type.lower().replace("-", "_")
-        self.entity_id = f"sensor.{SENSOR_PREFIX}{waste_type}"
+        self.entity_id = f"sensor.{slugify(SENSOR_PREFIX + waste_type)}"
         self._attr_unique_id = self._make_unique_id(config, waste_type)
         self._attr_icon = self._icon_for_waste_type(waste_type)
 

--- a/custom_components/afvalwijzer/sensor_provider.py
+++ b/custom_components/afvalwijzer/sensor_provider.py
@@ -13,7 +13,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, slugify
 
 from .const.const import (
     ATTR_DAYS_UNTIL_COLLECTION_DATE,
@@ -117,7 +117,7 @@ class ProviderSensor(CoordinatorEntity, RestoreEntity, SensorEntity):
 
         self._attr_has_entity_name = True
         self._attr_translation_key = waste_type.lower().replace("-", "_")
-        self.entity_id = f"sensor.{SENSOR_PREFIX}{waste_type}"
+        self.entity_id = f"sensor.{slugify(SENSOR_PREFIX + waste_type)}"
         self._attr_unique_id = self._make_unique_id(config, waste_type)
         self._attr_icon = self._icon_for_waste_type(waste_type)
 


### PR DESCRIPTION
### Summary
This PR resolves deprecation warnings introduced in Home Assistant Core regarding invalid `entity_id` formats. It ensures all entity IDs generated by the integration use standard slugification without spaces or invalid characters.

### Key Changes
- Updated `SENSOR_PREFIX` in `const/const.py` to use an underscore (`"afvalwijzer_"`) instead of a trailing space (`"afvalwijzer "`).
- Integrated `homeassistant.util.slugify` into `sensor_custom.py` and `sensor_provider.py` to guarantee completely safe entity IDs for all dynamically generated waste types.

### Why this is needed
Home Assistant has tightened validation rules for manually constructed `entity_id`s. Passing invalid characters (such as spaces) now emits warnings in the log: `Detected that custom integration 'afvalwijzer' sets an invalid entity ID: 'sensor.afvalwijzer restafval'`. If left unaddressed, this strict validation will hard-fail in Home Assistant version 2027.2.0. This fix maintains full compatibility and a clean runtime log for users.
