### PR TITLE
feat(calendar): show the full pickup schedule instead of only the next pickup per type

### DIFF
--- a/custom_components/afvalwijzer/calendar.py
+++ b/custom_components/afvalwijzer/calendar.py
@@ -12,6 +12,18 @@ from .const.const import CONF_COLLECTOR, CONF_EXCLUDE_LIST, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+# Waste type names that are abbreviations and should be fully uppercased
+# in event summaries instead of capitalized ("GFT", not "Gft").
+_ABBREVIATIONS = {"gft", "pmd", "kca"}
+
+
+def _display_type(waste_type: str) -> str:
+    """Return a human-friendly display name for a waste type."""
+    name = waste_type.strip()
+    if name.lower() in _ABBREVIATIONS:
+        return name.upper()
+    return name.capitalize()
+
 
 def _to_date(value) -> date | None:
     """Coerce a waste data value (str, datetime or date) into a date.
@@ -81,7 +93,7 @@ class AfvalwijzerCalendar(CalendarEntity):
         for event_date, waste_type in upcoming_events:
             if event_date == next_event_date and waste_type not in types_on_next_date:
                 types_on_next_date.append(waste_type)
-        summary_text = f"{collector.capitalize()}: {', '.join([wt.capitalize() for wt in types_on_next_date])}"
+        summary_text = f"{collector.capitalize()}: {', '.join([_display_type(wt) for wt in types_on_next_date])}"
 
         return CalendarEvent(
             summary=summary_text,
@@ -138,7 +150,7 @@ class AfvalwijzerCalendar(CalendarEntity):
             end = start + timedelta(days=1)
 
             if start_date.date() <= start <= end_date.date():
-                summary_text = f"{collector.capitalize()}: {waste_type.capitalize()}"
+                summary_text = f"{collector.capitalize()}: {_display_type(waste_type)}"
 
                 events.append(
                     CalendarEvent(

--- a/custom_components/afvalwijzer/calendar.py
+++ b/custom_components/afvalwijzer/calendar.py
@@ -38,6 +38,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     coordinator = hass.data.get(DOMAIN, {}).get(entry_id, {}).get("coordinator")
 
     if coordinator:
+        _LOGGER.debug("Setting up Afvalwijzer calendar for entry: %s", entry_id)
         async_add_entities([AfvalwijzerCalendar(coordinator, entry_id)])
     else:
         _LOGGER.error("Afvalwijzer Calendar: Could not find coordinator!")
@@ -95,6 +96,9 @@ class AfvalwijzerCalendar(CalendarEntity):
         if raw:
             items = ((item.get("type", ""), item.get("date")) for item in raw)
         else:
+            _LOGGER.debug(
+                "No raw schedule on coordinator; falling back to next-per-type data"
+            )
             source = self.coordinator.waste_data_with_today or {}
             items = source.items()
 
@@ -139,4 +143,10 @@ class AfvalwijzerCalendar(CalendarEntity):
                     )
                 )
 
+        _LOGGER.debug(
+            "Calendar returning %d event(s) between %s and %s",
+            len(events),
+            start_date.date(),
+            end_date.date(),
+        )
         return events

--- a/custom_components/afvalwijzer/calendar.py
+++ b/custom_components/afvalwijzer/calendar.py
@@ -125,7 +125,8 @@ class AfvalwijzerCalendar(CalendarEntity):
         include_today = self.coordinator.config.get("include_today", True)
         collector = self.coordinator.config.get(CONF_COLLECTOR, "Afvalwijzer")
 
-        for waste_type, event_date in self._full_schedule():
+        schedule = self._full_schedule()
+        for waste_type, event_date in schedule:
             if not include_today and event_date == today:
                 continue
 
@@ -144,9 +145,10 @@ class AfvalwijzerCalendar(CalendarEntity):
                 )
 
         _LOGGER.debug(
-            "Calendar returning %d event(s) between %s and %s",
+            "Calendar returning %d event(s) between %s and %s (full schedule: %d entries)",
             len(events),
             start_date.date(),
             end_date.date(),
+            len(schedule),
         )
         return events

--- a/custom_components/afvalwijzer/calendar.py
+++ b/custom_components/afvalwijzer/calendar.py
@@ -8,7 +8,7 @@ import logging
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.util import dt as dt_util
 
-from .const.const import CONF_COLLECTOR, DOMAIN
+from .const.const import CONF_COLLECTOR, CONF_EXCLUDE_LIST, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,19 +57,14 @@ class AfvalwijzerCalendar(CalendarEntity):
         """Return the next upcoming event."""
         today = dt_util.now().date()
         include_today = self.coordinator.config.get("include_today", True)
-        waste_source = self.coordinator.waste_data_with_today or {}
         collector = self.coordinator.config.get(CONF_COLLECTOR, "Afvalwijzer")
 
         upcoming_events = []
-        for waste_type, event_date in waste_source.items():
-            event_date_only = _to_date(event_date)
-            if event_date_only is None:
+        for waste_type, event_date in self._full_schedule():
+            if not include_today and event_date == today:
                 continue
-
-            if not include_today and event_date_only == today:
-                continue
-            if event_date_only >= today:
-                upcoming_events.append((event_date_only, waste_type))
+            if event_date >= today:
+                upcoming_events.append((event_date, waste_type))
 
         if not upcoming_events:
             return None
@@ -77,7 +72,10 @@ class AfvalwijzerCalendar(CalendarEntity):
         upcoming_events.sort(key=lambda x: x[0])
         next_event_date = upcoming_events[0][0]
 
-        types_on_next_date = [wt for ed, wt in upcoming_events if ed == next_event_date]
+        types_on_next_date = []
+        for event_date, waste_type in upcoming_events:
+            if event_date == next_event_date and waste_type not in types_on_next_date:
+                types_on_next_date.append(waste_type)
         summary_text = f"{collector.capitalize()}: {', '.join([wt.capitalize() for wt in types_on_next_date])}"
 
         return CalendarEvent(
@@ -86,27 +84,48 @@ class AfvalwijzerCalendar(CalendarEntity):
             end=next_event_date + timedelta(days=1),
         )
 
+    def _full_schedule(self) -> list[tuple[str, date]]:
+        """Return the full pickup schedule as (waste_type, date) pairs.
+
+        Prefers the raw schedule (every future date for every type). Falls
+        back to the next-date-per-type data for caches written before the
+        raw schedule was stored.
+        """
+        raw = getattr(self.coordinator, "waste_data_raw", None) or []
+        if raw:
+            items = ((item.get("type", ""), item.get("date")) for item in raw)
+        else:
+            source = self.coordinator.waste_data_with_today or {}
+            items = source.items()
+
+        exclude_raw = str(self.coordinator.config.get(CONF_EXCLUDE_LIST, ""))
+        exclude = {x.strip() for x in exclude_raw.lower().split(",") if x.strip()}
+
+        schedule: list[tuple[str, date]] = []
+        for waste_type, value in items:
+            event_date = _to_date(value)
+            if event_date is None or not waste_type:
+                continue
+            if waste_type.strip().lower() in exclude:
+                continue
+            schedule.append((waste_type, event_date))
+        return schedule
+
     async def async_get_events(
         self, hass, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
-        """Get the calendar events."""
+        """Get the calendar events in the requested range."""
         events = []
         today = dt_util.now().date()
 
         include_today = self.coordinator.config.get("include_today", True)
-        waste_source = self.coordinator.waste_data_with_today or {}
-
         collector = self.coordinator.config.get(CONF_COLLECTOR, "Afvalwijzer")
 
-        for waste_type, event_date in waste_source.items():
-            event_date_only = _to_date(event_date)
-            if event_date_only is None:
+        for waste_type, event_date in self._full_schedule():
+            if not include_today and event_date == today:
                 continue
 
-            if not include_today and event_date_only == today:
-                continue
-
-            start = event_date_only
+            start = event_date
             end = start + timedelta(days=1)
 
             if start_date.date() <= start <= end_date.date():

--- a/custom_components/afvalwijzer/calendar.py
+++ b/custom_components/afvalwijzer/calendar.py
@@ -38,7 +38,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     coordinator = hass.data.get(DOMAIN, {}).get(entry_id, {}).get("coordinator")
 
     if coordinator:
-        _LOGGER.debug("Setting up Afvalwijzer calendar for entry: %s", entry_id)
+        _LOGGER.debug(
+            "Setting up Afvalwijzer calendar for entry: %s (schedule: %d entries)",
+            entry_id,
+            len(getattr(coordinator, "waste_data_raw", None) or []),
+        )
         async_add_entities([AfvalwijzerCalendar(coordinator, entry_id)])
     else:
         _LOGGER.error("Afvalwijzer Calendar: Could not find coordinator!")

--- a/custom_components/afvalwijzer/collector/main_collector.py
+++ b/custom_components/afvalwijzer/collector/main_collector.py
@@ -186,6 +186,11 @@ class MainCollector:
             return []
 
     @property
+    def waste_data_raw(self):
+        """Return the full parsed pickup schedule (all future dates, all types)."""
+        return self._waste_data.waste_data_raw
+
+    @property
     def waste_data_with_today(self):
         """Return waste data including today's pickups."""
         return self._waste_data.waste_data_with_today

--- a/custom_components/afvalwijzer/common/sensor_utils.py
+++ b/custom_components/afvalwijzer/common/sensor_utils.py
@@ -27,6 +27,38 @@ from ..const.const import (
     DOMAIN,
 )
 
+# Icons per provider waste type, shared by the provider sensors and the
+# dynamic next_type sensor icon.
+WASTE_TYPE_ICONS: dict[str, str] = {
+    "best-tas": "mdi:bag-personal",
+    "gft": "mdi:flower",
+    "glas": "mdi:glass-fragile",
+    "grofvuil": "mdi:sofa",
+    "kca": "mdi:flask-outline",
+    "kerstbomen": "mdi:pine-tree",
+    "grip": "mdi:truck-cargo-container",
+    "luiers": "mdi:baby-carriage",
+    "maas": "mdi:truck-cargo-container",
+    "milieubus": "mdi:truck-cargo-container",
+    "papier": "mdi:newspaper",
+    "plastic": "mdi:bottle-soda-classic",
+    "pmd": "mdi:bottle-soda-classic",
+    "pmd-restafval": "mdi:trash-can-outline",
+    "restafval": "mdi:trash-can",
+    "sorti": "mdi:sort-variant",
+    "textiel": "mdi:tshirt-crew",
+    "restwagen": "mdi:trash-can",
+    "restafvalzakken": "mdi:sack",
+    "snoeiafval": "mdi:leaf",
+    "tuinafval": "mdi:leaf",
+    "notifications": "mdi:bell",
+}
+
+
+def icon_for_waste_type(waste_type: str, default: str | None = None) -> str | None:
+    """Return the icon for a provider waste type, or `default` if unknown."""
+    return WASTE_TYPE_ICONS.get(waste_type, default)
+
 
 def is_naive(value: datetime) -> bool:
     """Return True if the datetime is timezone-naive."""

--- a/custom_components/afvalwijzer/coordinator.py
+++ b/custom_components/afvalwijzer/coordinator.py
@@ -60,6 +60,7 @@ class AfvalwijzerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.waste_data_with_today: dict[str, Any] = {}
         self.waste_data_without_today: dict[str, Any] = {}
         self.waste_data_custom: dict[str, Any] = {}
+        self.waste_data_raw: list[dict[str, Any]] = []
         self.notification_data: list[Any] = []
 
     async def async_load_cache(self) -> bool:
@@ -124,6 +125,7 @@ class AfvalwijzerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.waste_data_with_today = data.get("waste_data_with_today", {})
         self.waste_data_without_today = data.get("waste_data_without_today", {})
         self.waste_data_custom = data.get("waste_data_custom", {})
+        self.waste_data_raw = data.get("waste_data_raw", [])
         self.notification_data = data.get("notification_data", [])
 
     def _fetch_data(self) -> dict[str, Any]:
@@ -146,5 +148,6 @@ class AfvalwijzerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "waste_data_with_today": collector.waste_data_with_today,
             "waste_data_without_today": collector.waste_data_without_today,
             "waste_data_custom": collector.waste_data_custom,
+            "waste_data_raw": collector.waste_data_raw,
             "notification_data": collector.notification_data,
         }

--- a/custom_components/afvalwijzer/sensor_custom.py
+++ b/custom_components/afvalwijzer/sensor_custom.py
@@ -104,6 +104,8 @@ class CustomSensor(CoordinatorEntity, SensorEntity):
                 return "mdi:calendar-multiselect"
             case "next_in_days":
                 return "mdi:counter"
+            case "next_type":
+                return "mdi:recycle"
             case _:
                 _LOGGER.debug("No specific icon for: %s", waste_type)
                 return SENSOR_ICON

--- a/custom_components/afvalwijzer/sensor_custom.py
+++ b/custom_components/afvalwijzer/sensor_custom.py
@@ -17,6 +17,7 @@ from .common.sensor_utils import (
     as_utc_aware,
     build_device_info,
     date_to_local_midnight,
+    icon_for_waste_type,
     make_unique_id,
     translate_value,
 )
@@ -142,6 +143,8 @@ class CustomSensor(CoordinatorEntity, SensorEntity):
                 raise ValueError(f"No data for custom sensor: {self.waste_type}")
 
             raw_value = waste_data_custom[self.waste_type]
+            if self.waste_type == "next_type":
+                self._attr_icon = self._next_type_icon(raw_value)
             translated_val = translate_value(raw_value, self._config, self.coordinator)
             self._apply_value(translated_val)
             self._last_update = dt_util.now().isoformat()
@@ -156,6 +159,21 @@ class CustomSensor(CoordinatorEntity, SensorEntity):
             self._set_error_state()
 
         self.async_write_ha_state()
+
+    @staticmethod
+    def _next_type_icon(value: Any) -> str:
+        """Return the icon of the waste type the next_type sensor reports.
+
+        Falls back to the generic label icon when the value is not a single
+        known waste type (e.g. "gft, papier" or the default label).
+        """
+        if isinstance(value, str):
+            types = [t.strip().lower() for t in value.split(",") if t.strip()]
+            if len(types) == 1:
+                icon = icon_for_waste_type(types[0])
+                if icon:
+                    return icon
+        return "mdi:label-outline"
 
     def _apply_value(self, value: Any) -> None:
         """Apply collector output to sensor state."""
@@ -205,6 +223,8 @@ class CustomSensor(CoordinatorEntity, SensorEntity):
 
     def _set_error_state(self) -> None:
         """Set a safe fallback state on errors."""
+        if self.waste_type == "next_type":
+            self._attr_icon = "mdi:label-outline"
         self._fallback_state = self._cfg.default_label
         self._days_until_collection_date = None
         self._attr_device_class = None

--- a/custom_components/afvalwijzer/sensor_custom.py
+++ b/custom_components/afvalwijzer/sensor_custom.py
@@ -105,7 +105,7 @@ class CustomSensor(CoordinatorEntity, SensorEntity):
             case "next_in_days":
                 return "mdi:counter"
             case "next_type":
-                return "mdi:recycle"
+                return "mdi:label-outline"
             case _:
                 _LOGGER.debug("No specific icon for: %s", waste_type)
                 return SENSOR_ICON

--- a/custom_components/afvalwijzer/sensor_provider.py
+++ b/custom_components/afvalwijzer/sensor_provider.py
@@ -17,6 +17,7 @@ from .common.sensor_utils import (
     as_utc_aware,
     build_device_info,
     date_to_local_midnight,
+    icon_for_waste_type,
     make_unique_id,
     translate_value,
 )
@@ -125,34 +126,11 @@ class ProviderSensor(CoordinatorEntity, SensorEntity):
 
     @staticmethod
     def _icon_for_waste_type(waste_type: str) -> str:
-        match waste_type:
-            case "best-tas":
-                return "mdi:bag-personal"
-            case "gft":
-                return "mdi:flower"
-            case "glas":
-                return "mdi:glass-fragile"
-            case "grofvuil":
-                return "mdi:sofa"
-            case "kerstbomen":
-                return "mdi:pine-tree"
-            case "grip" | "maas" | "milieubus":
-                return "mdi:truck-cargo-container"
-            case "papier":
-                return "mdi:newspaper"
-            case "plastic" | "pmd":
-                return "mdi:bottle-soda-classic"
-            case "restafval" | "restwagen":
-                return "mdi:trash-can"
-            case "restafvalzakken":
-                return "mdi:sack"
-            case "snoeiafval" | "tuinafval":
-                return "mdi:leaf"
-            case "notifications":
-                return "mdi:bell"
-            case _:
-                _LOGGER.debug("No specific icon for: %s", waste_type)
-                return SENSOR_ICON
+        icon = icon_for_waste_type(waste_type)
+        if icon is None:
+            _LOGGER.debug("No specific icon for: %s", waste_type)
+            return SENSOR_ICON
+        return icon
 
     @staticmethod
     def _resolve_include_today(config: dict[str, Any]) -> bool:

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -36,7 +36,7 @@ async def test_calendar_event_parsing_fallback():
 
     assert len(events) == 4
     assert events[0].summary == "Afvalthuis: GFT"
-    assert events[1].summary == "Afvalthuis: Pmd"
+    assert events[1].summary == "Afvalthuis: PMD"
     assert events[2].summary == "Afvalthuis: Restafval"
     assert events[3].summary == "Afvalthuis: Papier"
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -8,25 +8,31 @@ import pytest
 from custom_components.afvalwijzer.calendar import AfvalwijzerCalendar
 
 
-@pytest.mark.asyncio
-async def test_calendar_event_parsing():
-    """Test that the calendar handles mixed date types correctly."""
+def _mock_coordinator(*, raw=None, with_today=None, config=None):
     mock_data = MagicMock()
-    mock_data.config = {"include_today": True, "provider": "afvalthuis"}
+    mock_data.config = config or {"include_today": True, "provider": "afvalthuis"}
+    mock_data.waste_data_raw = raw or []
+    mock_data.waste_data_with_today = with_today or {}
+    return mock_data
 
-    mock_data.waste_data_with_today = {
-        "gft": "2026-07-09",
-        "pmd": date(2026, 7, 10),
-        "restafval": datetime(2026, 7, 11),
-        "papier": "2026-07-12T00:00:00",
-    }
+
+@pytest.mark.asyncio
+async def test_calendar_event_parsing_fallback():
+    """Without a raw schedule the calendar falls back to next-per-type data."""
+    mock_data = _mock_coordinator(
+        with_today={
+            "gft": "2026-07-09",
+            "pmd": date(2026, 7, 10),
+            "restafval": datetime(2026, 7, 11),
+            "papier": "2026-07-12T00:00:00",
+        }
+    )
 
     calendar = AfvalwijzerCalendar(mock_data, "test_entry_id")
 
-    start_date = datetime(2026, 7, 1)
-    end_date = datetime(2026, 7, 31)
-
-    events = await calendar.async_get_events(None, start_date, end_date)
+    events = await calendar.async_get_events(
+        None, datetime(2026, 7, 1), datetime(2026, 7, 31)
+    )
 
     assert len(events) == 4
     assert events[0].summary == "Afvalthuis: Gft"
@@ -36,20 +42,47 @@ async def test_calendar_event_parsing():
 
 
 @pytest.mark.asyncio
-async def test_calendar_handles_cache_restored_iso_strings():
-    """Data restored from cache stores datetimes as full ISO strings.
+async def test_calendar_full_schedule_multiple_dates_per_type():
+    """The raw schedule yields every future pickup, not just the next one."""
+    mock_data = _mock_coordinator(
+        raw=[
+            {"type": "gft", "date": "2026-07-09"},
+            {"type": "gft", "date": "2026-07-23"},
+            {"type": "gft", "date": "2026-08-06"},
+            {"type": "restafval", "date": "2026-07-16"},
+            {"type": "restafval", "date": "2026-08-13"},
+        ]
+    )
 
-    Regression test: these were silently dropped because only the
-    YYYY-MM-DD format was parsed.
-    """
-    mock_data = MagicMock()
-    mock_data.config = {"include_today": True, "provider": "afvalthuis"}
+    calendar = AfvalwijzerCalendar(mock_data, "test_entry_id")
 
-    mock_data.waste_data_with_today = {
-        "gft": "2026-07-09T00:00:00",
-        "restafval": "2026-07-10T00:00:00+02:00",
-        "geen_datum": "geen",
+    events = await calendar.async_get_events(
+        None, datetime(2026, 7, 1), datetime(2026, 8, 31)
+    )
+    assert len(events) == 5
+
+    # Only the events inside the requested range are returned
+    july_events = await calendar.async_get_events(
+        None, datetime(2026, 7, 1), datetime(2026, 7, 31)
+    )
+    assert len(july_events) == 3
+    assert {e.start for e in july_events} == {
+        date(2026, 7, 9),
+        date(2026, 7, 16),
+        date(2026, 7, 23),
     }
+
+
+@pytest.mark.asyncio
+async def test_calendar_full_schedule_handles_cache_iso_strings():
+    """Raw schedule entries restored from cache store dates as ISO strings."""
+    mock_data = _mock_coordinator(
+        raw=[
+            {"type": "gft", "date": "2026-07-09T00:00:00"},
+            {"type": "restafval", "date": "2026-07-10T00:00:00+02:00"},
+            {"type": "kapot", "date": "geen"},
+        ]
+    )
 
     calendar = AfvalwijzerCalendar(mock_data, "test_entry_id")
 
@@ -60,3 +93,48 @@ async def test_calendar_handles_cache_restored_iso_strings():
     assert len(events) == 2
     assert events[0].start == date(2026, 7, 9)
     assert events[1].start == date(2026, 7, 10)
+
+
+@pytest.mark.asyncio
+async def test_calendar_respects_exclude_list():
+    """Waste types on the exclude list do not appear in the calendar."""
+    mock_data = _mock_coordinator(
+        raw=[
+            {"type": "gft", "date": "2026-07-09"},
+            {"type": "papier", "date": "2026-07-10"},
+        ],
+        config={
+            "include_today": True,
+            "provider": "afvalthuis",
+            "exclude_list": "papier",
+        },
+    )
+
+    calendar = AfvalwijzerCalendar(mock_data, "test_entry_id")
+
+    events = await calendar.async_get_events(
+        None, datetime(2026, 7, 1), datetime(2026, 7, 31)
+    )
+
+    assert len(events) == 1
+    assert events[0].summary == "Afvalthuis: Gft"
+
+
+def test_calendar_next_event_groups_types_on_same_date():
+    """The next-event state groups all types collected on the same day."""
+    today = date.today().isoformat()
+    mock_data = _mock_coordinator(
+        raw=[
+            {"type": "gft", "date": today},
+            {"type": "papier", "date": today},
+            {"type": "gft", "date": "2099-01-01"},
+        ],
+        config={"include_today": True, "provider": "mijnafvalwijzer"},
+    )
+
+    calendar = AfvalwijzerCalendar(mock_data, "test_entry_id")
+    event = calendar.event
+
+    assert event is not None
+    assert event.start == date.today()
+    assert event.summary == "Mijnafvalwijzer: Gft, Papier"

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -35,7 +35,7 @@ async def test_calendar_event_parsing_fallback():
     )
 
     assert len(events) == 4
-    assert events[0].summary == "Afvalthuis: Gft"
+    assert events[0].summary == "Afvalthuis: GFT"
     assert events[1].summary == "Afvalthuis: Pmd"
     assert events[2].summary == "Afvalthuis: Restafval"
     assert events[3].summary == "Afvalthuis: Papier"
@@ -117,7 +117,7 @@ async def test_calendar_respects_exclude_list():
     )
 
     assert len(events) == 1
-    assert events[0].summary == "Afvalthuis: Gft"
+    assert events[0].summary == "Afvalthuis: GFT"
 
 
 def test_calendar_next_event_groups_types_on_same_date():
@@ -137,4 +137,4 @@ def test_calendar_next_event_groups_types_on_same_date():
 
     assert event is not None
     assert event.start == date.today()
-    assert event.summary == "Mijnafvalwijzer: Gft, Papier"
+    assert event.summary == "Mijnafvalwijzer: GFT, Papier"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -25,6 +25,10 @@ _DATA = {
     "waste_data_with_today": {"restafval": "2026-07-23"},
     "waste_data_without_today": {"restafval": "2026-07-23"},
     "waste_data_custom": {"next_date": "2026-07-23"},
+    "waste_data_raw": [
+        {"type": "restafval", "date": "2026-07-23"},
+        {"type": "restafval", "date": "2026-08-06"},
+    ],
     "notification_data": ["note"],
 }
 
@@ -39,6 +43,7 @@ def _make_coordinator(config=None):
     coordinator.waste_data_with_today = {}
     coordinator.waste_data_without_today = {}
     coordinator.waste_data_custom = {}
+    coordinator.waste_data_raw = []
     coordinator.notification_data = []
     return coordinator
 
@@ -98,6 +103,7 @@ async def test_async_load_cache_applies_fresh_cache():
     assert await coordinator.async_load_cache() is True
     assert coordinator.data == _DATA
     assert coordinator.waste_data_with_today == _DATA["waste_data_with_today"]
+    assert coordinator.waste_data_raw == _DATA["waste_data_raw"]
     assert coordinator.notification_data == ["note"]
 
 

--- a/tests/test_sensor_custom.py
+++ b/tests/test_sensor_custom.py
@@ -98,6 +98,41 @@ def test_custom_sensor_fallback_when_no_full_timestamp():
     assert sensor.native_value == target.isoformat()
 
 
+def test_next_type_icon_follows_waste_type():
+    """The next_type sensor icon matches the waste type it reports."""
+    coordinator = FakeCoordinator(None)
+    coordinator.waste_data_custom = {"next_type": "restafval"}
+
+    cfg = {
+        CONF_COLLECTOR: "mijnafvalwijzer",
+        CONF_POSTAL_CODE: "1234AB",
+        CONF_HOUSE_NUMBER: "1",
+        CONF_SUFFIX: "",
+        CONF_DEFAULT_LABEL: "geen",
+    }
+
+    sensor = CustomSensor(_make_hass(), "next_type", coordinator, cfg)
+    sensor.async_write_ha_state = MagicMock()
+
+    sensor._handle_coordinator_update()
+    assert sensor.icon == "mdi:trash-can"
+
+    # A single different type switches the icon
+    coordinator.waste_data_custom = {"next_type": "gft"}
+    sensor._handle_coordinator_update()
+    assert sensor.icon == "mdi:flower"
+
+    # Multiple types on the same date fall back to the generic label icon
+    coordinator.waste_data_custom = {"next_type": "gft, papier"}
+    sensor._handle_coordinator_update()
+    assert sensor.icon == "mdi:label-outline"
+
+    # Default label (no upcoming pickup) also falls back
+    coordinator.waste_data_custom = {"next_type": "geen"}
+    sensor._handle_coordinator_update()
+    assert sensor.icon == "mdi:label-outline"
+
+
 async def test_added_to_hass_populates_initial_state():
     """Adding the sensor applies data the coordinator already holds."""
     today = dt_util.now().date()


### PR DESCRIPTION
## Summary

The calendar previously only showed the *next* pickup per waste type, because it read the reduced next-date-per-type structure built for the sensors — even though collectors fetch the full schedule (typically the entire calendar year). Scrolling the HA calendar forward a month showed nothing.

The full parsed schedule is now kept on the coordinator and the calendar iterates it, so every month view shows all scheduled pickups the provider publishes. Verified live: a real mijnafvalwijzer address serves 85 schedule entries, with every month through December populated in the HA calendar view.

Along the way this PR also adds calendar debug logging, makes the `next_type` sensor icon follow the waste type it reports, and completes the waste type icon map.

## Calendar: full schedule

- `MainCollector` exposes `waste_data_raw` (the full parsed schedule, which was already being built and then discarded)
- The coordinator stores it in memory and in the `.storage` cache, so it survives restarts
- `async_get_events` iterates the full schedule filtered to the requested range — no config option needed, since the HA calendar API is range-queried and the UI asks for exactly the window being viewed
- The calendar now respects the `exclude_list` option (previously ignored by the calendar)
- Graceful upgrade: when loading a cache written by an older version (no raw schedule yet), the calendar falls back to the next-per-type data until the next refresh
- Next-event state groups and deduplicates types collected on the same day

## Calendar: debug logging

The calendar previously logged nothing in normal operation. Now (all at debug level):

- Setup: `Setting up Afvalwijzer calendar for entry: <id> (schedule: 85 entries)`
- Per view query: `Calendar returning 7 event(s) between 2026-08-01 and 2026-08-31 (full schedule: 85 entries)`
- A fallback notice when serving next-per-type data because no raw schedule is available

## Sensor icons

- The waste type icon mapping moved from a `match` statement inside `ProviderSensor` to a shared map in `common/sensor_utils.py`
- The `next_type` sensor icon now follows the waste type it reports (`mdi:trash-can` for restafval, `mdi:flower` for gft, …), consistent with the dynamic notifications bell; multiple types on one date or the default label fall back to `mdi:label-outline`
- Added icons for the five canonical waste types that had none and silently used the generic default: `kca`, `luiers`, `pmd-restafval`, `sorti`, `textiel`
- All 25 icon names in the integration validated against the official MDI registry

## Notes

- The only remaining calendar horizon is provider-side: municipalities publish through the calendar year, so e.g. January of next year stays empty until they publish it
- Sensor states and attributes are unchanged; only the calendar data source and icons changed

## Verification

- 77 tests passing (new: multi-date-per-type, range filtering, cached ISO strings, exclude list, same-day grouping, dynamic next_type icon); ruff clean
- Tested live in HA: full 2026 schedule visible in the calendar, per-month query logging confirmed, dynamic icon confirmed