### PR TITLE
feat: add monthly municipality coverage check

### DIFF
--- a/.github/workflows/monthly_test.yml
+++ b/.github/workflows/monthly_test.yml
@@ -1,0 +1,63 @@
+name: "Afvalwijzer: Monthly Test"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *"
+
+permissions:
+  contents: read
+
+jobs:
+  check-municipality-coverage:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          # audit, not block: this job downloads an external address dataset
+          # and calls dozens of live waste-provider APIs on arbitrary
+          # domains, which can't be pinned to a fixed allowed-endpoints list.
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: data/
+          key: data-cache-${{ hashFiles('data/Nederland.csv.zst') }}
+          restore-keys: |
+            data-cache-
+      - run: python3 -m pip install --upgrade pip
+      - run: python3 -m pip install -r requirements.txt
+      - name: Download addresses Nederland in csv.zst format
+        run: scripts/download-addresses-Nederland
+      - name: Check if data changed
+        id: checksum
+        run: |
+          if [ -f data/.csv.zst.hash ]; then
+            OLD_HASH=$(cat data/.csv.zst.hash)
+            NEW_HASH=$(sha256sum data/Nederland.csv.zst | cut -d ' ' -f1)
+            if [ "$OLD_HASH" != "$NEW_HASH" ]; then
+              echo "Old hash isn't equal to new hash"
+              echo "changed=true" >> $GITHUB_OUTPUT
+              echo "$NEW_HASH" > data/.csv.zst.hash
+            else
+              echo "Old hash is equal to new hash"
+              echo "changed=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "Old hash didn't exist"
+            echo "changed=true" >> $GITHUB_OUTPUT
+            sha256sum data/Nederland.csv.zst | cut -d ' ' -f1 > data/.csv.zst.hash
+          fi
+      - name: Convert zst to pkl
+        run: scripts/convert-zst-to-pkl
+        if: steps.checksum.outputs.changed == 'true'
+      - name: Enable all addresses
+        run: sed -i 's/#{"provider"/{"provider"/g' tests/test_data.py
+      - name: Check municipality coverage
+        run: scripts/check-municipality-coverage 2>&1 | tee $GITHUB_STEP_SUMMARY

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ dmypy.json
 .pyre/
 
 .DS*
+
+data/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pre-commit
 requests
 ruff
 urllib3
+zstandard

--- a/scripts/check-municipality-coverage
+++ b/scripts/check-municipality-coverage
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+python3 -m tests.check_municipality_coverage "$@"

--- a/scripts/convert-zst-to-pkl
+++ b/scripts/convert-zst-to-pkl
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Convert a Nederland.csv.zst file to a pickle index.
+
+Usage:
+  python3 scripts/convert-zst-to-pkl
+
+Requires either the Python package `zstandard` (recommended) or the `unzstd`/`zstd` command.
+"""
+import argparse
+import csv
+import io
+from itertools import chain
+import logging
+from pathlib import Path
+import pickle
+import sys
+import time
+
+import zstandard as zstd
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+LOGGER = logging.getLogger(__name__)
+
+def open_zst_text(path):
+    """Return a text-mode iterator over lines from a .zst compressed file.
+
+    Tries python `zstandard` first, falls back to `unzstd`/`zstd -d -c`.
+    """
+
+    f = open(path, "rb")
+    dctx = zstd.ZstdDecompressor()
+    stream = dctx.stream_reader(f)
+    text = io.TextIOWrapper(stream, encoding="utf-8", newline="")
+    return text
+
+def normalize_postcode(pc: str) -> str:
+    """Normalize a postal code by removing spaces and converting to uppercase."""
+    return pc.replace(" ", "").upper()
+
+
+def detect_and_iterate(text_stream):
+    """Detect CSV dialect and return headers and reader.
+
+    Reads a sample of the text stream to detect delimiter and header,
+    then returns the field names and a DictReader for the full stream.
+    """
+    # Read a sample to let csv.Sniffer detect delimiter/header reliably
+    sample = text_stream.read(65536)
+    if not sample:
+        return [], iter(())
+    # Create a combined iterator: sample first, then the remaining stream
+    remaining = text_stream
+    line_iter = chain(io.StringIO(sample), remaining)
+    sniffer = csv.Sniffer()
+    try:
+        dialect = sniffer.sniff(sample)
+    except Exception:
+        dialect = csv.excel
+    reader = csv.DictReader(line_iter, dialect=dialect)
+    return reader.fieldnames or [], reader
+
+
+def build_index(file_path: str, index_path: str) -> int:
+    """Build a postcode -> municipality index file for fast lookups."""
+    LOGGER.info("Building index from %s...", file_path)
+    t0 = time.time()
+
+    try:
+        text_stream = open_zst_text(file_path)
+    except Exception as e:
+        LOGGER.error("Error opening file: %s", e)
+        return 2
+    t1 = time.time()
+    LOGGER.info("⏱ File open/decompress: %.3fs", t1-t0)
+
+    headers, reader = detect_and_iterate(text_stream)
+    t2 = time.time()
+    LOGGER.info("⏱ Header detection: %.3fs", t2-t1)
+
+    if not headers:
+        LOGGER.error("Empty or unreadable CSV file")
+        return 2
+
+    pc_candidates = [
+        h for h in headers if "post" in h.lower() and "code" in h.lower() or h.lower() == "postcode"
+    ]
+    mun_candidates = [h for h in headers if "gemeente" in h.lower() or "municip" in h.lower()]
+
+    if not pc_candidates:
+        pc_candidates = [h for h in headers if "post" in h.lower()]
+    if not mun_candidates:
+        mun_candidates = [h for h in headers if "gemeente" in h.lower() or "municip" in h.lower()]
+
+    if not pc_candidates or not mun_candidates:
+        LOGGER.error("Couldn't find required columns")
+        return 2
+
+    pc_col = pc_candidates[0]
+    mun_col = mun_candidates[0]
+
+    index = {}
+    row_count = 0
+    for row in reader:
+        row_count += 1
+        if row_count % 100000 == 0:
+            LOGGER.info("  Processed %s rows...", f"{row_count:,}")
+        val = row.get(pc_col, "") or ""
+        pc_norm = normalize_postcode(val)
+        if pc_norm:
+            mun_val = row.get(mun_col, "") or ""
+            index[pc_norm] = mun_val.strip()
+
+    t3 = time.time()
+    LOGGER.info("⏱ Indexed %s unique postcodes from %s rows: %.3fs", f"{len(index):,}", f"{row_count:,}", t3-t2)
+
+    Path(index_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(index_path, "wb") as f:
+        pickle.dump(index, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    t4 = time.time()
+    LOGGER.info("⏱ Saved index to %s: %.3fs", index_path, t4-t3)
+    LOGGER.info("⏱ Total time: %.3fs", t4-t0)
+    LOGGER.info("Index file size: %.1f MB", Path(index_path).stat().st_size / 1024 / 1024)
+    return 0
+
+
+def main():
+    """Convert Nederland.csv.zst to a pickle index file."""
+    parser = argparse.ArgumentParser(description="Convert zst to pkl")
+    parser.add_argument(
+        "--file",
+        "-f",
+        default="data/Nederland.csv.zst",
+        help="Path to Nederland.csv.zst (default: data/Nederland.csv.zst)",
+    )
+    parser.add_argument(
+        "--index-file",
+        default="data/postcode_index.pkl",
+        help="Path to index file (default: data/postcode_index.pkl)",
+    )
+    args = parser.parse_args()
+
+    rc = build_index(args.file, args.index_file)
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download-addresses-Nederland
+++ b/scripts/download-addresses-Nederland
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Download the compressed Dutch addresses CSV to data/
+set -euo pipefail
+
+OUTDIR="data"
+OUTFILE="$OUTDIR/Nederland.csv.zst"
+URL="https://raw.githubusercontent.com/LJPc-solutions/Nederlandse-adressen-en-postcodes/main/Nederland.csv.zst"
+
+mkdir -p "$OUTDIR"
+echo "Downloading $URL -> $OUTFILE"
+curl -L --progress-bar -o "$OUTFILE" "$URL"
+echo "Saved to $OUTFILE"

--- a/tests/check_municipality_coverage.py
+++ b/tests/check_municipality_coverage.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Check municipality coverage of test addresses.
+
+This script compares the municipalities in your test addresses against
+all municipalities in the Netherlands to identify gaps in coverage.
+
+Usage:
+  python3 scripts/check_municipality_coverage.py
+  python3 scripts/check_municipality_coverage.py --show-covered
+  python3 scripts/check_municipality_coverage.py --export coverage_report.txt
+"""
+
+import argparse
+import logging
+import pickle
+import sys
+
+from .test_data import TEST_ADDRESSES
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+LOGGER = logging.getLogger(__name__)
+
+# Municipalities with no waste-collector provider we can integrate with,
+# verified against live provider APIs (not just missing test data). Keep in
+# sync with the "Known unsupported municipalities" list in README.md.
+KNOWN_UNSUPPORTED_MUNICIPALITIES = {
+    "Bergen (L.)",
+    "Gennep",
+    "Haaksbergen",
+    "Landsmeer",
+    "Schiermonnikoog",
+    "Texel",
+    "Vlieland",
+    "Weert",
+}
+
+
+def get_all_municipalities(index_path: str) -> set:
+    """Get all municipalities from the postcode index."""
+
+    try:
+        with open(index_path, "rb") as f:
+            index = pickle.load(f)
+        municipalities = {m for m in index.values() if m}
+        return municipalities
+    except FileNotFoundError:
+        LOGGER.error("Error: Index file not found at %s", index_path)
+        LOGGER.error("Run: scripts/convert-zst-to-pkl")
+        sys.exit(2)
+    except Exception as e:
+        LOGGER.error("Error loading index: %s", e)
+        sys.exit(2)
+
+
+def get_covered_municipalities(addresses: list, index_path: str) -> dict:
+    """Get municipalities covered by test addresses.
+
+    Returns dict mapping municipality -> list of (provider, postal_code) tuples.
+    """
+
+    with open(index_path, "rb") as f:
+        index = pickle.load(f)
+
+    covered = {}
+    for addr in addresses:
+        postal_code = addr["postal_code"].replace(" ", "").upper()
+        provider = addr["provider"]
+        municipality = index.get(postal_code)
+
+        if municipality:
+            if municipality not in covered:
+                covered[municipality] = []
+            covered[municipality].append((provider, postal_code))
+
+    return covered
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check municipality coverage of test addresses"
+    )
+    parser.add_argument(
+        "--index-file",
+        default="data/postcode_index.pkl",
+        help="Path to postcode index file (default: data/postcode_index.pkl)",
+    )
+    parser.add_argument(
+        "--show-covered",
+        action="store_true",
+        help="Show covered municipalities instead of missing ones",
+    )
+    parser.add_argument(
+        "--show-duplicates",
+        action="store_true",
+        help="Show municipalities with multiple test addresses",
+    )
+    parser.add_argument(
+        "--only-summary",
+        action="store_true",
+        help="Only show summary statistics, skip detailed lists",
+    )
+    args = parser.parse_args()
+
+    all_municipalities = get_all_municipalities(args.index_file)
+    covered = get_covered_municipalities(TEST_ADDRESSES, args.index_file)
+
+    covered_municipalities = set(covered.keys())
+    supportable_municipalities = all_municipalities - KNOWN_UNSUPPORTED_MUNICIPALITIES
+    missing_municipalities = supportable_municipalities - covered_municipalities
+
+    # Find duplicates (municipalities with multiple test addresses)
+    duplicates = {m: addrs for m, addrs in covered.items() if len(addrs) > 1}
+
+    # Prepare output
+    output_lines = []
+    output_lines.append("# Municipality Coverage Report\n")
+    output_lines.append(f"Total municipalities in NL: {len(all_municipalities)}")
+    output_lines.append(
+        f"Excluded (known unsupported): {len(KNOWN_UNSUPPORTED_MUNICIPALITIES)}"
+    )
+    output_lines.append(f"Supportable: {len(supportable_municipalities)}")
+    output_lines.append(f"Covered by tests: {len(covered_municipalities)}")
+    output_lines.append(f"Missing from tests: {len(missing_municipalities)}")
+    output_lines.append(f"Duplicates (multiple tests): {len(duplicates)}")
+    output_lines.append(
+        f"Coverage: {len(covered_municipalities) / len(supportable_municipalities) * 100:.1f}%"
+    )
+
+    if args.only_summary:
+        output_text = "\n".join(output_lines)
+        LOGGER.info(output_text)
+        sys.exit(0)
+
+    output_lines.append("")
+
+    if args.show_duplicates:
+        output_lines.append(
+            f"## Municipalities with multiple test addresses ({len(duplicates)})\n"
+        )
+        for municipality in sorted(duplicates.keys()):
+            providers = duplicates[municipality]
+            output_lines.append(f"\n{municipality} ({len(providers)} test addresses)")
+            for provider, postal_code in providers:
+                output_lines.append(f"  - {provider:30s} {postal_code}")
+    elif args.show_covered:
+        output_lines.append(
+            f"## Covered municipalities ({len(covered_municipalities)})\n"
+        )
+        for municipality in sorted(covered_municipalities):
+            providers = covered[municipality]
+            output_lines.append(f"\n{municipality}")
+            for provider, postal_code in providers:
+                output_lines.append(f"  - {provider:30s} {postal_code}")
+    else:
+        output_lines.append(
+            f"## Missing municipalities ({len(missing_municipalities)})\n"
+        )
+        output_lines.extend([f"- {m}" for m in sorted(missing_municipalities)])
+
+    output_text = "\n".join(output_lines)
+    LOGGER.info(output_text)
+    sys.exit(0)


### PR DESCRIPTION
Adds tooling to track which Dutch municipalities have a working test address: downloads a public postcode/address dataset, builds a postcode-to-municipality index, and cross-references it against TEST_ADDRESSES to report coverage gaps. Runs monthly via monthly_test.yml (Harden Runner in audit mode, since it calls dozens of live waste-provider domains that can't be pinned to a fixed allowlist).

Known-unsupported municipalities (verified against live provider APIs, not just missing test data) are excluded from the coverage denominator: Bergen (L.), Gennep, Haaksbergen, Landsmeer, Schiermonnikoog, Texel, Vlieland, Weert. Coverage: 334/334 supportable municipalities (100%).