### PR TITLE
fix(lint): resolve PLR0917 too-many-positional-arguments

### DIFF
--- a/custom_components/afvalwijzer/collector/circulus.py
+++ b/custom_components/afvalwijzer/collector/circulus.py
@@ -100,9 +100,9 @@ def _ensure_authenticated_address(
     url: str,
     response: dict[str, Any],
     logged_in_cookies: requests.cookies.RequestsCookieJar,
+    *,
     house_number: str,
     suffix: str,
-    *,
     timeout: tuple[float, float],
     verify: bool,
 ) -> None:
@@ -207,8 +207,8 @@ def get_waste_data_raw(
             url,
             response,
             logged_in_cookies,
-            house_number,
-            suffix,
+            house_number=house_number,
+            suffix=suffix,
             timeout=timeout,
             verify=verify,
         )

--- a/custom_components/afvalwijzer/collector/main_collector.py
+++ b/custom_components/afvalwijzer/collector/main_collector.py
@@ -65,6 +65,7 @@ class MainCollector:
         house_number: str,
         suffix: str,
         street_name: str,
+        *,
         exclude_pickup_today,
         exclude_list: str,
         default_label: str,

--- a/custom_components/afvalwijzer/collector/opzet.py
+++ b/custom_components/afvalwijzer/collector/opzet.py
@@ -67,6 +67,7 @@ def _get_bag_id(
     postal_code: str,
     house_number: str,
     suffix: str,
+    *,
     timeout: tuple[float, float],
     verify: bool,
 ) -> str | None:
@@ -143,7 +144,13 @@ def get_waste_data_raw(
 
     try:
         bag_id = _get_bag_id(
-            session, base_url, postal_code, house_number, suffix, timeout, verify
+            session,
+            base_url,
+            postal_code,
+            house_number,
+            suffix,
+            timeout=timeout,
+            verify=verify,
         )
         if not bag_id:
             _LOGGER.warning("Address/bag_id not found!")
@@ -235,7 +242,13 @@ def get_notification_data_raw(
 
     try:
         bag_id = _get_bag_id(
-            session, base_url, postal_code, house_number, suffix, timeout, verify
+            session,
+            base_url,
+            postal_code,
+            house_number,
+            suffix,
+            timeout=timeout,
+            verify=verify,
         )
         if not bag_id:
             _LOGGER.debug("No bag_id found for notifications")

--- a/custom_components/afvalwijzer/collector/ximmio.py
+++ b/custom_components/afvalwijzer/collector/ximmio.py
@@ -79,8 +79,8 @@ def _fetch_address_data(
     provider: str,
     postal_code: str,
     house_number: str,
-    suffix: str,
     *,
+    suffix: str,
     timeout: tuple[float, float],
 ) -> dict[str, Any]:
     data: dict[str, Any] = {
@@ -107,10 +107,10 @@ def _fetch_waste_data_raw_temp(
     url: str,
     provider: str,
     unique_id: str,
+    *,
     community: str,
     start_date: datetime,
     end_date: str,
-    *,
     timeout: tuple[float, float],
 ) -> dict[str, Any]:
     start_date_str = start_date.strftime("%Y-%m-%d")
@@ -204,7 +204,7 @@ def get_waste_data_raw(
             provider,
             postal_code,
             house_number,
-            suffix,
+            suffix=suffix,
             timeout=timeout,
         )
 
@@ -226,9 +226,9 @@ def get_waste_data_raw(
             url,
             provider,
             unique_id,
-            community,
-            now,
-            end_date,
+            community=community,
+            start_date=now,
+            end_date=end_date,
             timeout=timeout,
         )
 

--- a/custom_components/afvalwijzer/coordinator.py
+++ b/custom_components/afvalwijzer/coordinator.py
@@ -137,9 +137,9 @@ class AfvalwijzerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.config.get(CONF_HOUSE_NUMBER),
                 self.config.get(CONF_SUFFIX),
                 self.config.get(CONF_STREET_NAME),
-                self.config.get(CONF_EXCLUDE_PICKUP_TODAY),
-                self.config.get(CONF_EXCLUDE_LIST),
-                self.config.get(CONF_DEFAULT_LABEL),
+                exclude_pickup_today=self.config.get(CONF_EXCLUDE_PICKUP_TODAY),
+                exclude_list=self.config.get(CONF_EXCLUDE_LIST),
+                default_label=self.config.get(CONF_DEFAULT_LABEL),
             )
         except Exception as err:
             raise UpdateFailed(f"Collector initialization failed: {err}") from err

--- a/tests/test_happy_flow.py
+++ b/tests/test_happy_flow.py
@@ -27,9 +27,9 @@ def test_main_collector_happy_flow():
             "1",
             "",
             "",
-            "False",
-            "",
-            "geen",
+            exclude_pickup_today="False",
+            exclude_list="",
+            default_label="geen",
         )
 
         types = [t.lower() for t in collector.waste_types_provider]

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -4,7 +4,8 @@ Author: Bram van Dartel - xirixiz
 
 Usage:
 from afvalwijzer.collector.main_collector import MainCollector
-MainCollector('<provider>','<postal_code>','<house_number>','<suffix>','<street_name>','True','True','geen')
+MainCollector('<provider>','<postal_code>','<house_number>','<suffix>','<street_name>',
+              exclude_pickup_today='True', exclude_list='True', default_label='geen')
 
 Run test:
 - Update this file with your information (or the information you would like to test with, examples are in that file)
@@ -51,9 +52,9 @@ def _run_for_entry(entry: dict, show_failures_only: bool = False) -> bool:
         house_number,
         suffix,
         street_name,
-        exclude_pickup_today,
-        exclude_list,
-        default_label,
+        exclude_pickup_today=exclude_pickup_today,
+        exclude_list=exclude_list,
+        default_label=default_label,
     )
 
     if collector.waste_data_with_today == {} or collector.waste_types_provider == []:


### PR DESCRIPTION
## What

CI installs `ruff` unpinned (`pip install ruff` in `ci.yml`), so a newer ruff release started flagging `PLR0917 Too many positional arguments` in code that was clean when it was written. The **Check style formatting** job went red on every PR for reasons unrelated to the PR's own changes.

This converts the surplus parameters into keyword-only arguments, matching the style the newer collectors already use, and updates the call sites.

| File | Made keyword-only |
|---|---|
| `collector/circulus.py` | `house_number`, `suffix` in `_ensure_authenticated_address` |
| `collector/opzet.py` | `timeout`, `verify` in `_get_bag_id` |
| `collector/ximmio.py` | `suffix` in `_fetch_address_data`; `community`, `start_date`, `end_date` in `_fetch_waste_data_raw_temp` |
| `collector/main_collector.py` | `exclude_pickup_today`, `exclude_list`, `default_label` in `MainCollector.__init__` |

Call sites updated: `coordinator.py`, `tests/test_module.py`, `tests/test_happy_flow.py` (plus the usage docstring in `test_module.py`).

## Stacked on #637

`collector/recycleapp.py` tripped the same rule (`access_token` in `_fetch_waste_data_raw_temp`), and #637 already removes that parameter as part of the RecycleApp API migration. Since neither PR could go green alone, **this PR targets `fix/recycleapp` instead of `main`.**

Merge order: this PR into `fix/recycleapp`, then #637 into `main`.

## Verification

- `ruff check .` clean and `ruff format --check .` clean (62 files) on the stacked tree
- `pytest tests` unchanged
- Live fetch through the changed signatures: opzet (hvc, cyclus), ximmio (avalex, twentemilieu) and circulus all return their normal waste types

No behaviour change.
