### PR TITLE
chore(deps): pin lint tooling and enable Dependabot for pre-commit

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -34,19 +34,19 @@ updates:
       prefix: "chore"
       include: "scope"
 
-  # Pre-commit hooks (Ruff, Black, etc. if you use .pre-commit-config.yaml)
-  # - package-ecosystem: "pre-commit"
-  #   directory: "/"
-  #   schedule:
-  #     interval: "weekly"
-  #     day: "monday"
-  #   groups:
-  #     pre-commit:
-  #       patterns:
-  #         - "*"
-  #   labels:
-  #     - "dependencies"
-  #     - "pre-commit"
-  #   commit-message:
-  #     prefix: "chore"
-  #     include: "scope"
+  # Pre-commit hooks (.pre-commit-config.yaml)
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "pre-commit"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           python-version: "3.x"
           cache: "pip"
       - run: python3 -m pip install --upgrade pip
-      - run: python3 -m pip install ruff
+      - run: python3 -m pip install -c requirements.txt ruff
       - run: ruff check --output-format github .
 
   tests:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.14.9
+      rev: v0.16.2
       hooks:
           - id: ruff-check
             args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 homeassistant
-pre-commit
+pre-commit==4.6.1
 requests
-ruff
-urllib3
-zstandard
+ruff==0.16.2
+urllib3==2.7.0
+zstandard==0.25.0


### PR DESCRIPTION
## Why

The style job ran `pip install ruff` with no version, so it silently tracked whatever ruff released last. When a newer ruff started enforcing `PLR0917`, **Check style formatting** went red on code that was clean when it was written, blocking PRs that had nothing to do with it (fixed in #638). This makes the toolchain versions explicit and gives Dependabot a way to move them deliberately, in a PR you can see fail.

## Changes

| File | Change |
|---|---|
| `requirements.txt` | pin `ruff==0.16.2`, `pre-commit==4.6.1`, `urllib3==2.7.0`, `zstandard==0.25.0` |
| `.github/workflows/ci.yml` | style job installs ruff via `-c requirements.txt` |
| `.pre-commit-config.yaml` | `ruff-pre-commit` `v0.14.9` → `v0.16.2`, matching the pin |
| `.github/dependabot.yaml` | enable the `pre-commit` ecosystem (the block was already there, commented out) |

### Why `-c` instead of `-r`

`pip install -c requirements.txt ruff` applies the pin without installing anything else, so the style job keeps its ~25s runtime instead of pulling in homeassistant just to lint. Verified in a clean venv: it installs `ruff 0.16.2` and nothing else, and pointing the constraint at `ruff==0.16.1` installs 0.16.1 — the pin genuinely drives the version.

## What is deliberately left unpinned

`homeassistant` and `requests`, plus the pytest stack in `requirements_test.txt`. All of them are already hard-pinned upstream:

- `pytest-homeassistant-custom-component` pins `homeassistant==2026.2.3`, `pytest==9.0.0`, `pytest-cov==7.0.0`, `pytest-asyncio==1.3.0`, `pytest-timeout==2.4.0`
- `homeassistant` pins `requests==2.32.5`

Pinning those here would duplicate an upstream `==`, and Dependabot would open bump PRs that cannot resolve until the upstream package moves. The four packages that are pinned have no `==` constraint from anything else in the tree, so their bumps can actually merge.

Note that Dependabot's pip ecosystem has had nothing to do since **56767d9** (2025-12-22) stripped the version specifiers from `requirements.txt` — the last pip PR, #465, was closed unmerged the next day. This restores partial coverage.

## Verification

- clean-venv install through `-c` yields exactly `ruff 0.16.2`; constraint binding confirmed against a doctored `0.16.1` pin
- `pip install --dry-run -r requirements.txt -r requirements_test.txt` resolves, exit 0
- `pre-commit run --all-files` on the bumped rev: ruff check ✓, ruff format ✓
- `ruff check .` clean, `pytest tests` unchanged
