### PR TITLE
fix(sensor): create notifications sensor based on provider support, not current count

### DIFF
--- a/custom_components/afvalwijzer/collector/main_collector.py
+++ b/custom_components/afvalwijzer/collector/main_collector.py
@@ -63,28 +63,23 @@ NOTIFICATION_PROVIDERS = [
 ]
 
 
-def provider_supports_notifications(provider: str) -> bool:
-    """Return True if the given provider is known to support notifications.
-
-    This is a static capability check based only on the provider name, so it
-    can be used before any data has been fetched (e.g. to decide whether the
-    notifications sensor entity should exist at all).
-    """
-    provider = str(provider).strip().lower()
-    for sensor_set, _getter in NOTIFICATION_PROVIDERS:
-        keys = sensor_set.keys() if isinstance(sensor_set, dict) else sensor_set
-        if provider in keys:
-            return True
-    return False
-
-
 class MainCollector:
     """MainCollector collects and transforms waste data from various providers."""
 
     @staticmethod
     def provider_supports_notifications(provider: str) -> bool:
-        """Return True if the given provider is known to support notifications."""
-        return provider_supports_notifications(provider)
+        """Return True if the given provider is known to support notifications.
+
+        This is a static capability check based only on the provider name, so it
+        can be used before any data has been fetched (e.g. to decide whether the
+        notifications sensor entity should exist at all).
+        """
+        provider = str(provider).strip().lower()
+        for sensor_set, _getter in NOTIFICATION_PROVIDERS:
+            keys = sensor_set.keys() if isinstance(sensor_set, dict) else sensor_set
+            if provider in keys:
+                return True
+        return False
 
     def __init__(
         self,

--- a/custom_components/afvalwijzer/collector/main_collector.py
+++ b/custom_components/afvalwijzer/collector/main_collector.py
@@ -29,22 +29,6 @@ from ..const.const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-
-def provider_supports_notifications(provider: str) -> bool:
-    """Return True if the given provider is known to support notifications.
-
-    This is a static capability check based only on the provider name, so it
-    can be used before any data has been fetched (e.g. to decide whether the
-    notifications sensor entity should exist at all).
-    """
-    provider = str(provider).strip().lower()
-    for sensor_set in (SENSOR_COLLECTORS_OPZET, SENSOR_COLLECTORS_MIJNAFVALWIJZER):
-        keys = sensor_set.keys() if isinstance(sensor_set, dict) else sensor_set
-        if provider in keys:
-            return True
-    return False
-
-
 try:
     from . import (
         amsterdam,
@@ -69,6 +53,29 @@ try:
     )
 except ImportError as err:
     _LOGGER.error("Import error %s", err.args)
+
+# Providers with notification support, paired with their notification getter.
+# Shared by MainCollector._get_notification_data_raw (to fetch notifications)
+# and provider_supports_notifications (to check support without fetching).
+NOTIFICATION_PROVIDERS = [
+    (SENSOR_COLLECTORS_OPZET, opzet.get_notification_data_raw),
+    (SENSOR_COLLECTORS_MIJNAFVALWIJZER, mijnafvalwijzer.get_notification_data_raw),
+]
+
+
+def provider_supports_notifications(provider: str) -> bool:
+    """Return True if the given provider is known to support notifications.
+
+    This is a static capability check based only on the provider name, so it
+    can be used before any data has been fetched (e.g. to decide whether the
+    notifications sensor entity should exist at all).
+    """
+    provider = str(provider).strip().lower()
+    for sensor_set, _getter in NOTIFICATION_PROVIDERS:
+        keys = sensor_set.keys() if isinstance(sensor_set, dict) else sensor_set
+        if provider in keys:
+            return True
+    return False
 
 
 class MainCollector:
@@ -172,16 +179,7 @@ class MainCollector:
         """
 
         try:
-            # list of providers with notification support
-            notification_providers = [
-                (SENSOR_COLLECTORS_OPZET, opzet.get_notification_data_raw),
-                (
-                    SENSOR_COLLECTORS_MIJNAFVALWIJZER,
-                    mijnafvalwijzer.get_notification_data_raw,
-                ),
-            ]
-
-            for sensor_set, getter in notification_providers:
+            for sensor_set, getter in NOTIFICATION_PROVIDERS:
                 keys = sensor_set.keys() if isinstance(sensor_set, dict) else sensor_set
                 if self.provider in keys:
                     return getter(

--- a/custom_components/afvalwijzer/collector/main_collector.py
+++ b/custom_components/afvalwijzer/collector/main_collector.py
@@ -244,8 +244,3 @@ class MainCollector:
     def notification_count(self):
         """Returns the number of provider notifications."""
         return len(self._notification_data)
-
-    @property
-    def supports_notifications(self) -> bool:
-        """Return True if the configured provider supports notifications."""
-        return provider_supports_notifications(self.provider)

--- a/custom_components/afvalwijzer/collector/main_collector.py
+++ b/custom_components/afvalwijzer/collector/main_collector.py
@@ -29,6 +29,22 @@ from ..const.const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def provider_supports_notifications(provider: str) -> bool:
+    """Return True if the given provider is known to support notifications.
+
+    This is a static capability check based only on the provider name, so it
+    can be used before any data has been fetched (e.g. to decide whether the
+    notifications sensor entity should exist at all).
+    """
+    provider = str(provider).strip().lower()
+    for sensor_set in (SENSOR_COLLECTORS_OPZET, SENSOR_COLLECTORS_MIJNAFVALWIJZER):
+        keys = sensor_set.keys() if isinstance(sensor_set, dict) else sensor_set
+        if provider in keys:
+            return True
+    return False
+
+
 try:
     from . import (
         amsterdam,
@@ -230,3 +246,8 @@ class MainCollector:
     def notification_count(self):
         """Returns the number of provider notifications."""
         return len(self._notification_data)
+
+    @property
+    def supports_notifications(self) -> bool:
+        """Return True if the configured provider supports notifications."""
+        return provider_supports_notifications(self.provider)

--- a/custom_components/afvalwijzer/collector/main_collector.py
+++ b/custom_components/afvalwijzer/collector/main_collector.py
@@ -81,6 +81,11 @@ def provider_supports_notifications(provider: str) -> bool:
 class MainCollector:
     """MainCollector collects and transforms waste data from various providers."""
 
+    @staticmethod
+    def provider_supports_notifications(provider: str) -> bool:
+        """Return True if the given provider is known to support notifications."""
+        return provider_supports_notifications(provider)
+
     def __init__(
         self,
         provider: str,

--- a/custom_components/afvalwijzer/coordinator.py
+++ b/custom_components/afvalwijzer/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .collector.main_collector import MainCollector
+from .collector.main_collector import MainCollector, provider_supports_notifications
 from .const.const import (
     CONF_COLLECTOR,
     CONF_DEFAULT_LABEL,
@@ -62,6 +62,9 @@ class AfvalwijzerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.waste_data_custom: dict[str, Any] = {}
         self.waste_data_raw: list[dict[str, Any]] = []
         self.notification_data: list[Any] = []
+        self.supports_notifications = provider_supports_notifications(
+            config.get(CONF_COLLECTOR)
+        )
 
     async def async_load_cache(self) -> bool:
         """Load data from the cache."""

--- a/custom_components/afvalwijzer/coordinator.py
+++ b/custom_components/afvalwijzer/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .collector.main_collector import MainCollector, provider_supports_notifications
+from .collector.main_collector import MainCollector
 from .const.const import (
     CONF_COLLECTOR,
     CONF_DEFAULT_LABEL,
@@ -62,7 +62,7 @@ class AfvalwijzerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.waste_data_custom: dict[str, Any] = {}
         self.waste_data_raw: list[dict[str, Any]] = []
         self.notification_data: list[Any] = []
-        self.supports_notifications = provider_supports_notifications(
+        self.supports_notifications = MainCollector.provider_supports_notifications(
             config.get(CONF_COLLECTOR)
         )
 

--- a/custom_components/afvalwijzer/sensor.py
+++ b/custom_components/afvalwijzer/sensor.py
@@ -110,7 +110,7 @@ async def async_setup_entry(
                 entities.append(CustomSensor(hass, wtype, coordinator, config))
 
         if (
-            coordinator.notification_data
+            getattr(coordinator, "supports_notifications", False)
             and "notifications" not in known_provider_types
         ):
             known_provider_types.add("notifications")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -176,3 +176,36 @@ async def test_async_remove_cache_removes_store():
     build_mock.assert_called_once()
     assert build_mock.call_args.args[1] == "entry_123"
     store.async_remove.assert_awaited_once()
+
+
+def _make_real_coordinator(config):
+    """Build a coordinator by actually running AfvalwijzerDataUpdateCoordinator.__init__.
+
+    The HA base class's __init__ requires a fully set up hass (frame helper
+    etc.) that a bare MagicMock can't satisfy, so it's stubbed out here -
+    everything specific to our own __init__ body (config, supports_notifications,
+    ...) still runs for real.
+    """
+    with patch(
+        "custom_components.afvalwijzer.coordinator.DataUpdateCoordinator.__init__",
+        return_value=None,
+    ):
+        return AfvalwijzerDataUpdateCoordinator(MagicMock(), config, "entry")
+
+
+def test_init_sets_supports_notifications_for_capable_provider():
+    """A provider that supports notifications is detected at construction time.
+
+    This must be derivable from config alone (no fetch required), since
+    sensor.py decides whether to create the notifications entity before any
+    data has necessarily been fetched.
+    """
+    coordinator = _make_real_coordinator(dict(_CONFIG))
+    assert coordinator.supports_notifications is True
+
+
+def test_init_sets_supports_notifications_false_for_incapable_provider():
+    """A provider outside the known notification-capable sets is detected too."""
+    config = {**_CONFIG, CONF_COLLECTOR: "rova"}
+    coordinator = _make_real_coordinator(config)
+    assert coordinator.supports_notifications is False

--- a/tests/test_main_collector.py
+++ b/tests/test_main_collector.py
@@ -1,0 +1,35 @@
+"""Tests for provider_supports_notifications in main_collector.py."""
+
+from custom_components.afvalwijzer.collector.main_collector import (
+    provider_supports_notifications,
+)
+
+
+def test_opzet_provider_supports_notifications():
+    """A provider from the opzet collector set supports notifications."""
+    assert provider_supports_notifications("alphenaandenrijn") is True
+
+
+def test_mijnafvalwijzer_provider_supports_notifications():
+    """The mijnafvalwijzer provider supports notifications."""
+    assert provider_supports_notifications("mijnafvalwijzer") is True
+
+
+def test_unrelated_provider_does_not_support_notifications():
+    """A provider outside the known notification-capable sets returns False."""
+    assert provider_supports_notifications("rova") is False
+
+
+def test_unknown_provider_does_not_support_notifications():
+    """An unrecognized provider name returns False rather than raising."""
+    assert provider_supports_notifications("not_a_real_provider") is False
+
+
+def test_provider_supports_notifications_is_case_and_whitespace_insensitive():
+    """Matching is normalized the same way MainCollector normalizes provider."""
+    assert provider_supports_notifications(" MijnAfvalwijzer ") is True
+
+
+def test_provider_supports_notifications_handles_none():
+    """A missing provider (e.g. unset config) does not raise."""
+    assert provider_supports_notifications(None) is False

--- a/tests/test_main_collector.py
+++ b/tests/test_main_collector.py
@@ -1,35 +1,33 @@
-"""Tests for provider_supports_notifications in main_collector.py."""
+"""Tests for MainCollector.provider_supports_notifications in main_collector.py."""
 
-from custom_components.afvalwijzer.collector.main_collector import (
-    provider_supports_notifications,
-)
+from custom_components.afvalwijzer.collector.main_collector import MainCollector
 
 
 def test_opzet_provider_supports_notifications():
     """A provider from the opzet collector set supports notifications."""
-    assert provider_supports_notifications("alphenaandenrijn") is True
+    assert MainCollector.provider_supports_notifications("alphenaandenrijn") is True
 
 
 def test_mijnafvalwijzer_provider_supports_notifications():
     """The mijnafvalwijzer provider supports notifications."""
-    assert provider_supports_notifications("mijnafvalwijzer") is True
+    assert MainCollector.provider_supports_notifications("mijnafvalwijzer") is True
 
 
 def test_unrelated_provider_does_not_support_notifications():
     """A provider outside the known notification-capable sets returns False."""
-    assert provider_supports_notifications("rova") is False
+    assert MainCollector.provider_supports_notifications("rova") is False
 
 
 def test_unknown_provider_does_not_support_notifications():
     """An unrecognized provider name returns False rather than raising."""
-    assert provider_supports_notifications("not_a_real_provider") is False
+    assert MainCollector.provider_supports_notifications("not_a_real_provider") is False
 
 
 def test_provider_supports_notifications_is_case_and_whitespace_insensitive():
     """Matching is normalized the same way MainCollector normalizes provider."""
-    assert provider_supports_notifications(" MijnAfvalwijzer ") is True
+    assert MainCollector.provider_supports_notifications(" MijnAfvalwijzer ") is True
 
 
 def test_provider_supports_notifications_handles_none():
     """A missing provider (e.g. unset config) does not raise."""
-    assert provider_supports_notifications(None) is False
+    assert MainCollector.provider_supports_notifications(None) is False

--- a/tests/test_sensor_setup.py
+++ b/tests/test_sensor_setup.py
@@ -21,12 +21,15 @@ from custom_components.afvalwijzer.sensor_provider import ProviderSensor
 
 
 class _FakeCoordinator:
-    def __init__(self):
+    def __init__(self, *, supports_notifications=True, notification_data=None):
         today = date.today()
         self.waste_data_with_today = {"restafval": today}
         self.waste_data_without_today = {"restafval": today}
         self.waste_data_custom = {"next_date": today + timedelta(days=1)}
-        self.notification_data = ["fake_notification"]
+        self.notification_data = (
+            ["fake_notification"] if notification_data is None else notification_data
+        )
+        self.supports_notifications = supports_notifications
         self.data = {}
         self.config = {}
         self.listeners = []
@@ -97,6 +100,48 @@ async def test_setup_entry_creates_entities_and_notification_added():
     assert isinstance(added[1], CustomSensor)
     assert isinstance(added[2], ProviderSensor)
     assert added[2].waste_type == "notifications"
+
+
+async def test_notification_sensor_created_with_zero_notifications():
+    """The notifications sensor is created even when there are none right now.
+
+    Regression test: entity creation must be gated on provider capability
+    (coordinator.supports_notifications), not on the current notification
+    count, otherwise the sensor flickers in and out of existence depending
+    on whether any notifications happen to be pending at reload time.
+    """
+    hass = _make_hass()
+    coordinator = _FakeCoordinator(supports_notifications=True, notification_data=[])
+    entry = _make_entry(coordinator, hass, _CONFIG)
+
+    added = []
+
+    def _add_entities(entities):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, _add_entities)
+
+    notification_sensors = [
+        e for e in added if getattr(e, "waste_type", None) == "notifications"
+    ]
+    assert len(notification_sensors) == 1
+
+
+async def test_notification_sensor_not_created_when_unsupported():
+    """No notifications sensor is created for providers that don't support it."""
+    hass = _make_hass()
+    coordinator = _FakeCoordinator(supports_notifications=False, notification_data=[])
+    entry = _make_entry(coordinator, hass, _CONFIG)
+
+    added = []
+
+    def _add_entities(entities):
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, _add_entities)
+
+    assert len(added) == 2
+    assert all(getattr(e, "waste_type", None) != "notifications" for e in added)
 
 
 async def test_setup_entry_adds_new_waste_types_on_refresh():


### PR DESCRIPTION
## Problem

The notifications sensor was only created when `coordinator.notification_data` was non-empty at the moment entities were added. Since that check runs fresh on every integration reload, the sensor would silently vanish across a restart/reload if the notification count simply happened to be zero at that exact moment — even for providers that fully support notifications. It would only reappear once a later refresh happened to return a non-empty list.

## Fix

Entity creation is now gated on a new static capability check (`coordinator.supports_notifications`), derived from the configured provider rather than from the current data:

- `main_collector.py`: new `provider_supports_notifications(provider)` helper and a matching `MainCollector.supports_notifications` property.
- `coordinator.py`: computes `supports_notifications` from config at construction time, so it's available immediately, before any fetch completes.
- `sensor.py`: entity creation checks `coordinator.supports_notifications` instead of `coordinator.notification_data`.

## Result

For any provider that supports notifications, the sensor is now created exactly once and stays present for the lifetime of the config entry. It reports `0` whenever there are no pending notifications, and the actual count otherwise — it no longer flickers in and out of existence depending on whether anything happened to be pending at reload time.

## Tests

- New `tests/test_main_collector.py` covering `provider_supports_notifications` (opzet providers, mijnafvalwijzer, unsupported providers, case/whitespace handling, `None` input).
- New cases in `tests/test_coordinator.py` verifying `supports_notifications` is set correctly from config during real `__init__`.
- New cases in `tests/test_sensor_setup.py` verifying the sensor is created with zero notifications for a supporting provider, and not created at all for a non-supporting one.

All 87 tests pass; `ruff check` and `ruff format` clean.
