### PR TITLE
fix(calendar): remove orphaned pre-2026.1018 calendar entity on setup

### DIFF
--- a/custom_components/afvalwijzer/calendar.py
+++ b/custom_components/afvalwijzer/calendar.py
@@ -15,8 +15,8 @@ from .const.const import CONF_COLLECTOR, CONF_EXCLUDE_LIST, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 # unique_id used by the calendar entity before it was scoped per config
-# entry (pre-2026.1018); anyone upgrading from 2026.1017 gets an orphan
-# under it. Safe to drop once that version is far in the past.
+# entry in 2026.1018-b02; anyone who ran 2026.1015 through the builds
+# before that has an orphan under it. Safe to remove after 2027-08.
 _LEGACY_UNIQUE_ID = "afvalwijzer_calendar_filtered"
 
 # Waste type names that are abbreviations and should be fully uppercased

--- a/custom_components/afvalwijzer/calendar.py
+++ b/custom_components/afvalwijzer/calendar.py
@@ -15,8 +15,8 @@ from .const.const import CONF_COLLECTOR, CONF_EXCLUDE_LIST, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 # unique_id used by the calendar entity before it was scoped per config
-# entry (pre-2026.1018). Anyone updating from that era has an orphaned
-# entity under this id that nothing produces anymore.
+# entry (pre-2026.1018); anyone upgrading from 2026.1017 gets an orphan
+# under it. Safe to drop once that version is far in the past.
 _LEGACY_UNIQUE_ID = "afvalwijzer_calendar_filtered"
 
 # Waste type names that are abbreviations and should be fully uppercased
@@ -52,12 +52,11 @@ def _to_date(value) -> date | None:
 
 
 @callback
-def _async_remove_legacy_calendar(hass, entry_id: str) -> None:
+def _async_remove_legacy_calendar(hass) -> None:
     """Remove the orphaned pre-2026.1018 calendar entity, if present."""
     registry = er.async_get(hass)
-    for entry in er.async_entries_for_config_entry(registry, entry_id):
-        if entry.domain == "calendar" and entry.unique_id == _LEGACY_UNIQUE_ID:
-            registry.async_remove(entry.entity_id)
+    if entity_id := registry.async_get_entity_id("calendar", DOMAIN, _LEGACY_UNIQUE_ID):
+        registry.async_remove(entity_id)
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -65,7 +64,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     entry_id = getattr(config_entry, "entry_id", "test_entry_id")
     coordinator = hass.data.get(DOMAIN, {}).get(entry_id, {}).get("coordinator")
 
-    _async_remove_legacy_calendar(hass, entry_id)
+    _async_remove_legacy_calendar(hass)
 
     if coordinator:
         _LOGGER.debug(

--- a/custom_components/afvalwijzer/calendar.py
+++ b/custom_components/afvalwijzer/calendar.py
@@ -6,11 +6,18 @@ from datetime import date, datetime, timedelta
 import logging
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.core import callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from .const.const import CONF_COLLECTOR, CONF_EXCLUDE_LIST, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+# unique_id used by the calendar entity before it was scoped per config
+# entry (pre-2026.1018). Anyone updating from that era has an orphaned
+# entity under this id that nothing produces anymore.
+_LEGACY_UNIQUE_ID = "afvalwijzer_calendar_filtered"
 
 # Waste type names that are abbreviations and should be fully uppercased
 # in event summaries instead of capitalized ("GFT", not "Gft").
@@ -44,10 +51,21 @@ def _to_date(value) -> date | None:
     return None
 
 
+@callback
+def _async_remove_legacy_calendar(hass, entry_id: str) -> None:
+    """Remove the orphaned pre-2026.1018 calendar entity, if present."""
+    registry = er.async_get(hass)
+    for entry in er.async_entries_for_config_entry(registry, entry_id):
+        if entry.domain == "calendar" and entry.unique_id == _LEGACY_UNIQUE_ID:
+            registry.async_remove(entry.entity_id)
+
+
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Afvalwijzer calendar."""
     entry_id = getattr(config_entry, "entry_id", "test_entry_id")
     coordinator = hass.data.get(DOMAIN, {}).get(entry_id, {}).get("coordinator")
+
+    _async_remove_legacy_calendar(hass, entry_id)
 
     if coordinator:
         _LOGGER.debug(

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -10,6 +10,7 @@ from custom_components.afvalwijzer.calendar import (
     AfvalwijzerCalendar,
     _async_remove_legacy_calendar,
 )
+from custom_components.afvalwijzer.const.const import DOMAIN
 
 
 def _mock_coordinator(*, raw=None, with_today=None, config=None):
@@ -18,10 +19,6 @@ def _mock_coordinator(*, raw=None, with_today=None, config=None):
     mock_data.waste_data_raw = raw or []
     mock_data.waste_data_with_today = with_today or {}
     return mock_data
-
-
-def _registry_entry(entity_id, unique_id, domain="calendar"):
-    return SimpleNamespace(entity_id=entity_id, unique_id=unique_id, domain=domain)
 
 
 @pytest.mark.asyncio
@@ -150,64 +147,28 @@ def test_calendar_next_event_groups_types_on_same_date():
 
 def test_remove_legacy_calendar_cleans_up_pre_2026_1018_orphan():
     """Anyone updating straight from 2026.1017 has an orphan under the old global unique_id."""
-    legacy = _registry_entry(
-        "calendar.afvalwijzer_calendar", "afvalwijzer_calendar_filtered"
-    )
     registry = MagicMock()
+    registry.async_get_entity_id.return_value = "calendar.afvalwijzer_calendar"
 
-    with (
-        patch(
-            "custom_components.afvalwijzer.calendar.er.async_get", return_value=registry
-        ),
-        patch(
-            "custom_components.afvalwijzer.calendar.er.async_entries_for_config_entry",
-            return_value=[legacy],
-        ),
+    with patch(
+        "custom_components.afvalwijzer.calendar.er.async_get", return_value=registry
     ):
-        _async_remove_legacy_calendar(SimpleNamespace(), "test_entry")
+        _async_remove_legacy_calendar(SimpleNamespace())
 
+    registry.async_get_entity_id.assert_called_once_with(
+        "calendar", DOMAIN, "afvalwijzer_calendar_filtered"
+    )
     registry.async_remove.assert_called_once_with("calendar.afvalwijzer_calendar")
 
 
-def test_remove_legacy_calendar_leaves_current_entity_alone():
-    """The current per-entry calendar entity is not mistaken for the legacy one."""
-    current = _registry_entry(
-        "calendar.afvalwijzer_bonenakker", "afvalwijzer_calendar_test_entry"
-    )
+def test_remove_legacy_calendar_no_op_when_absent():
+    """Nothing is removed once the legacy entity is already gone."""
     registry = MagicMock()
+    registry.async_get_entity_id.return_value = None
 
-    with (
-        patch(
-            "custom_components.afvalwijzer.calendar.er.async_get", return_value=registry
-        ),
-        patch(
-            "custom_components.afvalwijzer.calendar.er.async_entries_for_config_entry",
-            return_value=[current],
-        ),
+    with patch(
+        "custom_components.afvalwijzer.calendar.er.async_get", return_value=registry
     ):
-        _async_remove_legacy_calendar(SimpleNamespace(), "test_entry")
-
-    registry.async_remove.assert_not_called()
-
-
-def test_remove_legacy_calendar_ignores_other_domains():
-    """A sensor entity is never mistaken for the legacy calendar entity."""
-    sensor_entry = _registry_entry(
-        "sensor.afvalwijzer_calendar_filtered",
-        "afvalwijzer_calendar_filtered",
-        domain="sensor",
-    )
-    registry = MagicMock()
-
-    with (
-        patch(
-            "custom_components.afvalwijzer.calendar.er.async_get", return_value=registry
-        ),
-        patch(
-            "custom_components.afvalwijzer.calendar.er.async_entries_for_config_entry",
-            return_value=[sensor_entry],
-        ),
-    ):
-        _async_remove_legacy_calendar(SimpleNamespace(), "test_entry")
+        _async_remove_legacy_calendar(SimpleNamespace())
 
     registry.async_remove.assert_not_called()

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,11 +1,15 @@
 """Test calendar for AfvalWijzer."""
 
 from datetime import date, datetime
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.afvalwijzer.calendar import AfvalwijzerCalendar
+from custom_components.afvalwijzer.calendar import (
+    AfvalwijzerCalendar,
+    _async_remove_legacy_calendar,
+)
 
 
 def _mock_coordinator(*, raw=None, with_today=None, config=None):
@@ -14,6 +18,10 @@ def _mock_coordinator(*, raw=None, with_today=None, config=None):
     mock_data.waste_data_raw = raw or []
     mock_data.waste_data_with_today = with_today or {}
     return mock_data
+
+
+def _registry_entry(entity_id, unique_id, domain="calendar"):
+    return SimpleNamespace(entity_id=entity_id, unique_id=unique_id, domain=domain)
 
 
 @pytest.mark.asyncio
@@ -138,3 +146,68 @@ def test_calendar_next_event_groups_types_on_same_date():
     assert event is not None
     assert event.start == date.today()
     assert event.summary == "Mijnafvalwijzer: GFT, Papier"
+
+
+def test_remove_legacy_calendar_cleans_up_pre_2026_1018_orphan():
+    """Anyone updating straight from 2026.1017 has an orphan under the old global unique_id."""
+    legacy = _registry_entry(
+        "calendar.afvalwijzer_calendar", "afvalwijzer_calendar_filtered"
+    )
+    registry = MagicMock()
+
+    with (
+        patch(
+            "custom_components.afvalwijzer.calendar.er.async_get", return_value=registry
+        ),
+        patch(
+            "custom_components.afvalwijzer.calendar.er.async_entries_for_config_entry",
+            return_value=[legacy],
+        ),
+    ):
+        _async_remove_legacy_calendar(SimpleNamespace(), "test_entry")
+
+    registry.async_remove.assert_called_once_with("calendar.afvalwijzer_calendar")
+
+
+def test_remove_legacy_calendar_leaves_current_entity_alone():
+    """The current per-entry calendar entity is not mistaken for the legacy one."""
+    current = _registry_entry(
+        "calendar.afvalwijzer_bonenakker", "afvalwijzer_calendar_test_entry"
+    )
+    registry = MagicMock()
+
+    with (
+        patch(
+            "custom_components.afvalwijzer.calendar.er.async_get", return_value=registry
+        ),
+        patch(
+            "custom_components.afvalwijzer.calendar.er.async_entries_for_config_entry",
+            return_value=[current],
+        ),
+    ):
+        _async_remove_legacy_calendar(SimpleNamespace(), "test_entry")
+
+    registry.async_remove.assert_not_called()
+
+
+def test_remove_legacy_calendar_ignores_other_domains():
+    """A sensor entity is never mistaken for the legacy calendar entity."""
+    sensor_entry = _registry_entry(
+        "sensor.afvalwijzer_calendar_filtered",
+        "afvalwijzer_calendar_filtered",
+        domain="sensor",
+    )
+    registry = MagicMock()
+
+    with (
+        patch(
+            "custom_components.afvalwijzer.calendar.er.async_get", return_value=registry
+        ),
+        patch(
+            "custom_components.afvalwijzer.calendar.er.async_entries_for_config_entry",
+            return_value=[sensor_entry],
+        ),
+    ):
+        _async_remove_legacy_calendar(SimpleNamespace(), "test_entry")
+
+    registry.async_remove.assert_not_called()


### PR DESCRIPTION
The `afvalwijzer_calendar_filtered` orphan cleanup affects every install upgrading from 2026.1015.

The calendar's `unique_id` used to be a single hardcoded string shared by every config entry; once it became scoped per entry, anyone updating from 2026.1015 is left with a registry entry under the old id that nothing produces anymore. This removes it unconditionally on setup, regardless of which calendar mode is active.