### PR TITLE
ci(release): adopt AwesomeVersion-compatible beta versions and gate releases on version match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "*"
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,26 @@ jobs:
             objects.githubusercontent.com:443
             uploads.github.com:443
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Verify manifest and const versions match the tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: scripts/verify-version "$TAG"
+      - name: Determine release type
+        id: release_type
+        env:
+          TAG: ${{ github.ref_name }}
+        # Betas are YYYY.SEQ.0bN, so match a trailing beta counter rather than
+        # the old "-b" tag style.
+        run: |
+          if [[ "$TAG" =~ b[0-9]+$ ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
       - run: zip -r ../../afvalwijzer.zip . -x "*/__pycache__/*" "__pycache__/*"
         working-directory: custom_components/afvalwijzer
       - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: "afvalwijzer.zip"
           generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, '-b') }}
+          prerelease: ${{ steps.release_type.outputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ permissions:
 jobs:
   release:
     runs-on: "ubuntu-latest"
+    env:
+      # Kept out of the run scripts themselves so the tag is never expanded
+      # into a shell command.
+      TAG: ${{ github.ref_name }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -27,13 +31,9 @@ jobs:
           # release; the default shallow checkout fetches none.
           fetch-depth: 0
       - name: Verify manifest and const versions match the tag
-        env:
-          TAG: ${{ github.ref_name }}
         run: scripts/verify-version "$TAG"
       - name: Determine release type
         id: release_type
-        env:
-          TAG: ${{ github.ref_name }}
         # Betas are YYYY.SEQ.0bN, so match a trailing beta counter rather than
         # the old "-b" tag style.
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ jobs:
   release:
     runs-on: "ubuntu-latest"
     env:
-      # Kept out of the run scripts themselves so the tag is never expanded
-      # into a shell command.
       TAG: ${{ github.ref_name }}
     steps:
       - name: Harden Runner
@@ -27,15 +25,11 @@ jobs:
             uploads.github.com:443
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Tags are needed to check the new one is newer than every existing
-          # release; the default shallow checkout fetches none.
           fetch-depth: 0
       - name: Verify manifest and const versions match the tag
         run: scripts/verify-version "$TAG"
       - name: Determine release type
         id: release_type
-        # Betas are YYYY.SEQ.0bN, so match a trailing beta counter rather than
-        # the old "-b" tag style.
         run: |
           if [[ "$TAG" =~ b[0-9]+$ ]]; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
             objects.githubusercontent.com:443
             uploads.github.com:443
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Tags are needed to check the new one is newer than every existing
+          # release; the default shallow checkout fetches none.
+          fetch-depth: 0
       - name: Verify manifest and const versions match the tag
         env:
           TAG: ${{ github.ref_name }}

--- a/scripts/verify-version
+++ b/scripts/verify-version
@@ -1,38 +1,108 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
+"""Verify the checked-out version is releasable as the given tag.
 
-set -e
+Checks, in order:
+  1. the tag is a well-formed version (YYYY.SEQ or YYYY.SEQ.0bN)
+  2. manifest.json and const.py both carry exactly that version
+  3. the tag is newer than every other release tag using this scheme
 
-cd "$(dirname "$0")/.."
+Deliberately dependency-free: the release workflow blocks all egress except
+GitHub, so it cannot pip-install anything. Ordering is computed from the
+version grammar rather than AwesomeVersion; tests/test_version_scheme.py
+cross-checks that the two agree.
+"""
 
-TAG="${1:?usage: scripts/verify-version <tag>}"
+import json
+import pathlib
+import re
+import subprocess
+import sys
 
-MANIFEST_VERSION="$(python3 -c '
-import json, pathlib
-print(json.loads(pathlib.Path("custom_components/afvalwijzer/manifest.json").read_text())["version"])
-')"
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
 
-CONST_VERSION="$(python3 -c '
-import pathlib, re
-text = pathlib.Path("custom_components/afvalwijzer/const/const.py").read_text()
-match = re.search(r"VERSION\s*=\s*\"([^\"]+)\"", text)
-print(match.group(1) if match else "")
-')"
+from update_version import VERSION_RE, sort_key  # noqa: E402
 
-status=0
+MANIFEST_PATH = REPO_ROOT / "custom_components/afvalwijzer/manifest.json"
+CONST_PATH = REPO_ROOT / "custom_components/afvalwijzer/const/const.py"
+CONST_VERSION_RE = re.compile(r'VERSION\s*=\s*"(?P<version>[^"]+)"')
 
-if [ "$MANIFEST_VERSION" != "$TAG" ]; then
-    echo "manifest.json version '$MANIFEST_VERSION' does not match tag '$TAG'" >&2
-    status=1
-fi
 
-if [ "$CONST_VERSION" != "$TAG" ]; then
-    echo "const.py VERSION '$CONST_VERSION' does not match tag '$TAG'" >&2
-    status=1
-fi
+def _manifest_version() -> str:
+    return str(json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))["version"])
 
-if [ "$status" -ne 0 ]; then
-    echo "Refusing to release: run 'python3 update_version.py' and retag." >&2
-    exit 1
-fi
 
-echo "Version OK: $TAG"
+def _const_version() -> str:
+    match = CONST_VERSION_RE.search(CONST_PATH.read_text(encoding="utf-8"))
+    return match.group("version") if match else ""
+
+
+def _existing_tags(exclude: str) -> list[str]:
+    """Return known release tags in this scheme, excluding the one being released.
+
+    Tags from older schemes (YYYY.MM.NN, the retired -bNN betas) do not parse and
+    are skipped: they predate this grammar and cannot be meaningfully compared.
+    """
+    result = subprocess.run(
+        ["git", "tag", "--list"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [
+        tag
+        for tag in (line.strip() for line in result.stdout.splitlines())
+        if tag and tag != exclude and VERSION_RE.match(tag)
+    ]
+
+
+def main() -> int:
+    """Verify the tag passed as the first argument."""
+    if len(sys.argv) != 2:
+        print("usage: scripts/verify-version <tag>", file=sys.stderr)
+        return 2
+
+    tag = sys.argv[1].strip()
+    errors: list[str] = []
+
+    if not VERSION_RE.match(tag):
+        print(
+            f"Tag '{tag}' is not a valid version; expected YYYY.SEQ or YYYY.SEQ.0bN.\n"
+            "Note that the retired '-bNN' beta suffix is rejected by AwesomeVersion, "
+            "which Home Assistant and HACS use to compare versions.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if (manifest_version := _manifest_version()) != tag:
+        errors.append(f"manifest.json version '{manifest_version}' does not match tag")
+
+    if (const_version := _const_version()) != tag:
+        errors.append(f"const.py VERSION '{const_version}' does not match tag")
+
+    if newer := [
+        t for t in _existing_tags(exclude=tag) if sort_key(t) >= sort_key(tag)
+    ]:
+        highest = max(newer, key=sort_key)
+        errors.append(
+            f"tag is not newer than existing release '{highest}'. "
+            "A beta sorts below its own stable release, so a sequence that has "
+            "already shipped cannot be re-opened as a beta; use the next sequence."
+        )
+
+    if errors:
+        for error in errors:
+            print(f"{tag}: {error}", file=sys.stderr)
+        print(
+            "Refusing to release: run 'python3 update_version.py' and retag.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Version OK: {tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-version
+++ b/scripts/verify-version
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+TAG="${1:?usage: scripts/verify-version <tag>}"
+
+MANIFEST_VERSION="$(python3 -c '
+import json, pathlib
+print(json.loads(pathlib.Path("custom_components/afvalwijzer/manifest.json").read_text())["version"])
+')"
+
+CONST_VERSION="$(python3 -c '
+import pathlib, re
+text = pathlib.Path("custom_components/afvalwijzer/const/const.py").read_text()
+match = re.search(r"VERSION\s*=\s*\"([^\"]+)\"", text)
+print(match.group(1) if match else "")
+')"
+
+status=0
+
+if [ "$MANIFEST_VERSION" != "$TAG" ]; then
+    echo "manifest.json version '$MANIFEST_VERSION' does not match tag '$TAG'" >&2
+    status=1
+fi
+
+if [ "$CONST_VERSION" != "$TAG" ]; then
+    echo "const.py VERSION '$CONST_VERSION' does not match tag '$TAG'" >&2
+    status=1
+fi
+
+if [ "$status" -ne 0 ]; then
+    echo "Refusing to release: run 'python3 update_version.py' and retag." >&2
+    exit 1
+fi
+
+echo "Version OK: $TAG"

--- a/tests/test_version_scheme.py
+++ b/tests/test_version_scheme.py
@@ -1,0 +1,76 @@
+"""Tests for the release version scheme.
+
+scripts/verify-version cannot import AwesomeVersion (the release workflow blocks
+egress to PyPI), so it orders versions using the version grammar instead. These
+tests are where that shortcut is justified: they assert every version the scheme
+can produce is valid AwesomeVersion, is correctly flagged as a pre-release, and
+orders the same way under both comparators.
+"""
+
+from awesomeversion import AwesomeVersion
+import pytest
+
+from update_version import compute_next_version, sort_key
+
+# Ascending order, mixing betas and stables across sequences and years.
+_ASCENDING = [
+    "2025.1042",
+    "2026.1000",
+    "2026.1018",
+    "2026.1019.0b1",
+    "2026.1019.0b2",
+    "2026.1019.0b10",
+    "2026.1019",
+    "2026.1020.0b1",
+    "2026.1020",
+]
+
+
+@pytest.mark.parametrize("version", _ASCENDING)
+def test_scheme_versions_are_valid_awesomeversion(version):
+    """Every version in the scheme parses as CalVer, not UNKNOWN."""
+    parsed = AwesomeVersion(version)
+    assert parsed.valid, f"{version} is not a valid AwesomeVersion"
+
+
+@pytest.mark.parametrize("version", _ASCENDING)
+def test_beta_flag_matches_the_grammar(version):
+    """AwesomeVersion agrees with the grammar about which versions are betas."""
+    assert AwesomeVersion(version).beta is ("0b" in version)
+
+
+def test_sort_key_orders_the_same_way_as_awesomeversion():
+    """The dependency-free comparator agrees with AwesomeVersion pairwise."""
+    for lower, higher in zip(_ASCENDING, _ASCENDING[1:], strict=False):
+        assert sort_key(lower) < sort_key(higher), f"{lower} !< {higher} (sort_key)"
+        assert AwesomeVersion(lower) < AwesomeVersion(higher), (
+            f"{lower} !< {higher} (AwesomeVersion)"
+        )
+
+
+def test_beta_sorts_below_its_own_stable():
+    """The rule that makes re-opening a shipped sequence impossible."""
+    assert sort_key("2026.1018.0b3") < sort_key("2026.1018")
+    assert AwesomeVersion("2026.1018.0b3") < AwesomeVersion("2026.1018")
+
+
+def test_retired_beta_suffix_is_rejected():
+    """The old '-bNN' style is why this scheme exists: AwesomeVersion can't use it."""
+    assert not AwesomeVersion("2026.1018-b01").valid
+    with pytest.raises(ValueError, match="not a recognised version"):
+        sort_key("2026.1018-b01")
+
+
+@pytest.mark.parametrize(
+    ("current", "beta", "expected"),
+    [
+        ("2026.1018", False, "2026.1019"),
+        ("2026.1018", True, "2026.1019.0b1"),
+        ("2026.1019.0b1", True, "2026.1019.0b2"),
+        ("2026.1019.0b2", False, "2026.1019"),
+    ],
+)
+def test_computed_versions_move_forward(current, beta, expected):
+    """Each step update_version.py can take is an increase, never a downgrade."""
+    assert compute_next_version(current, beta=beta) == expected
+    assert sort_key(current) < sort_key(expected)

--- a/update_version.py
+++ b/update_version.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Afvalwijzer integration."""
 
+import argparse
 from datetime import date
 import json
 import logging
@@ -13,32 +14,61 @@ LOGGER = logging.getLogger(__name__)
 MANIFEST_PATH = Path("custom_components/afvalwijzer/manifest.json")
 CONST_PATH = Path("custom_components/afvalwijzer/const/const.py")
 
-VERSION_RE = re.compile(r"^(?P<year>\d{4})\.(?P<seq>\d{4,})$")
-VERSION_ASSIGN_RE = re.compile(r'VERSION\s*=\s*"(?P<version>[0-9.]+)"')
+# YYYY.SEQ for a stable release, YYYY.SEQ.0bN for a beta. The ".0b" form is
+# what AwesomeVersion (used by HA and HACS) parses as a CalVer pre-release:
+# "2026.1019-b01" is rejected outright and raises when compared, and
+# "2026.1019b1" parses but is not recognised as a beta.
+VERSION_RE = re.compile(r"^(?P<year>\d{4})\.(?P<seq>\d{4,})(?:\.0b(?P<beta>\d+))?$")
+VERSION_ASSIGN_RE = re.compile(r'VERSION\s*=\s*"(?P<version>[^"]+)"')
+
+FIRST_SEQ = 1000
 
 
-def compute_next_version(current_version: str | None) -> str:
-    """Compute the next version string based on the current date and version."""
+def compute_next_version(current_version: str | None, *, beta: bool = False) -> str:
+    """Compute the next version string based on the current date and version.
+
+    A beta bumps the beta counter when one is already in progress, otherwise it
+    opens a beta for the next sequence number. A stable release promotes an
+    in-progress beta to its final version rather than skipping a sequence.
+    """
     current_year = date.today().year
 
-    if current_version:
+    if not current_version:
+        parsed = None
+    else:
         match = VERSION_RE.match(current_version.strip())
-        if match:
-            stored_year = int(match.group("year"))
-            stored_seq = int(match.group("seq"))
+        if not match:
+            # Refuse rather than silently restarting the sequence: resetting to
+            # FIRST_SEQ would move the version backwards and ship an update
+            # nobody can install over the top of.
+            raise ValueError(
+                f"Unrecognised current version {current_version!r}; "
+                "expected YYYY.SEQ or YYYY.SEQ.0bN"
+            )
+        parsed = match
 
-            if stored_year == current_year:
-                return f"{current_year}.{stored_seq + 1}"
-            return f"{current_year}.1000"
+    if parsed is None or int(parsed.group("year")) != current_year:
+        return (
+            f"{current_year}.{FIRST_SEQ}.0b1" if beta else f"{current_year}.{FIRST_SEQ}"
+        )
 
-    return f"{current_year}.1000"
+    seq = int(parsed.group("seq"))
+    current_beta = int(parsed.group("beta")) if parsed.group("beta") else None
+
+    if beta:
+        if current_beta is not None:
+            return f"{current_year}.{seq}.0b{current_beta + 1}"
+        return f"{current_year}.{seq + 1}.0b1"
+
+    if current_beta is not None:
+        return f"{current_year}.{seq}"
+    return f"{current_year}.{seq + 1}"
 
 
-def main() -> None:
-    """Update version numbers in manifest.json and const.py."""
+def _write_version(new_version: str) -> str | None:
+    """Write `new_version` to the manifest and const module, returning the old one."""
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     old_version = str(manifest.get("version", "")).strip() or None
-    new_version = compute_next_version(old_version)
 
     if manifest.get("version") != new_version:
         manifest["version"] = new_version
@@ -56,6 +86,39 @@ def main() -> None:
 
     if new_const_text != const_text:
         CONST_PATH.write_text(new_const_text, encoding="utf-8")
+
+    return old_version
+
+
+def main() -> None:
+    """Update version numbers in manifest.json and const.py."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--beta",
+        action="store_true",
+        help="cut a beta (YYYY.SEQ.0bN) instead of a stable release",
+    )
+    group.add_argument(
+        "--set",
+        dest="explicit",
+        metavar="VERSION",
+        help="set an explicit version instead of computing the next one",
+    )
+    args = parser.parse_args()
+
+    if args.explicit:
+        if not VERSION_RE.match(args.explicit.strip()):
+            parser.error(
+                f"Invalid version {args.explicit!r}; expected YYYY.SEQ or YYYY.SEQ.0bN"
+            )
+        new_version = args.explicit.strip()
+    else:
+        manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+        current = str(manifest.get("version", "")).strip() or None
+        new_version = compute_next_version(current, beta=args.beta)
+
+    old_version = _write_version(new_version)
 
     LOGGER.info("Updated version from %s to %s", old_version, new_version)
 

--- a/update_version.py
+++ b/update_version.py
@@ -24,6 +24,25 @@ VERSION_ASSIGN_RE = re.compile(r'VERSION\s*=\s*"(?P<version>[^"]+)"')
 FIRST_SEQ = 1000
 
 
+def sort_key(version: str) -> tuple[int, int, float]:
+    """Return an ordering key for a version in this scheme.
+
+    A stable release sorts above every beta of the same sequence number, which
+    is why an already-released sequence can never be re-opened as a beta. This
+    mirrors AwesomeVersion's ordering without needing it as a dependency; see
+    tests/test_version_scheme.py for the cross-check.
+    """
+    match = VERSION_RE.match(version)
+    if not match:
+        raise ValueError(f"not a recognised version: {version!r}")
+    beta = match.group("beta")
+    return (
+        int(match.group("year")),
+        int(match.group("seq")),
+        int(beta) if beta else float("inf"),
+    )
+
+
 def compute_next_version(current_version: str | None, *, beta: bool = False) -> str:
     """Compute the next version string based on the current date and version.
 


### PR DESCRIPTION
## Problem

Two separate issues with how releases are versioned today.

**The `-b01` beta suffix is not a usable version.** Home Assistant and HACS compare versions with AwesomeVersion, which rejects it outright:

```python
AwesomeVersion("2026.1018-b01").valid      # False, strategy=UNKNOWN
AwesomeVersion("2026.1018-b01") < AwesomeVersion("2026.1018")
# AwesomeVersionCompareException: Can't compare <unknown 2026.1018-b01> and <CalVer 2026.1018>
```

**Betas were never written to the manifest at all.** `2026.1018-b01`, `2026.1018-b02` and the withdrawn `2026.1018` stable all ship `"version": "2026.1018"`, so they are indistinguishable in HA analytics and in bug reports. #647 is a live example: the reporter said "Versie 2026.1018" and it took a round trip to work out which build they were actually on.

There is also a latent footgun in `update_version.py`: its regex only matches `YYYY.SEQ`, and anything else falls through to `return f"{current_year}.1000"`. Handed any beta string it would silently rewind `2026.1018` to `2026.1000`, an 18-release regression that ships an update nobody can install over the top of.

## Solution

**Format: `YYYY.SEQ.0bN`** (e.g. `2026.1019.0b1`), mirroring HA core's own `2026.8.0b1`. Of the candidates it is the only one that parses as CalVer, is flagged as a pre-release, and orders correctly:

| Candidate | valid | strategy | beta |
|---|---|---|---|
| `2026.1018-b01` | ❌ | UNKNOWN | - |
| `2026.1018b1` | ✅ | CalVer | ❌ not detected |
| `2026.1018.0b1` | ✅ | CalVer | ✅ |

**`update_version.py`** gains `--beta` and a `--set` escape hatch, and now refuses an unrecognised current version instead of silently resetting the sequence.

```
2026.1018      --beta  ->  2026.1019.0b1     open a beta for the next sequence
2026.1019.0b1  --beta  ->  2026.1019.0b2     bump the beta counter
2026.1019.0b1          ->  2026.1019         promote, no sequence skipped
2026.1018              ->  2026.1019         ordinary stable
2026.1025              ->  2027.1000         year rollover (pre-existing behaviour)
```

The sequence counter is per-year, not global: it restarts at 1000 each January, so `2026.1000` was the first release of 2026 and `2026.1018` is the nineteenth. The rollover is not a downgrade even though the counter visibly decreases, because the year is the primary sort key:

```
2026.1025 < 2027.1000  ->  sort_key=True   awesomeversion=True
    keys: (2026, 1025, inf)  vs  (2027, 1000, inf)
```

**`scripts/verify-version`** gates the release on three things: the tag is a well-formed version, `manifest.json` and `const.py` both carry exactly it, and it is newer than every existing release tag.

That last check exists because a beta sorts below its own stable, so re-opening a sequence that has already shipped produces a release HACS reads as a downgrade and never offers. Tagging `2026.1018.0b3` today, for instance, would reach only 82.8% of installs, stranding every one reporting `2026.1018`; `2026.1019.0b1` reaches 100%.

Note the check compares against tags that still exist. A version that shipped and was later withdrawn leaves no tag behind, so it cannot be detected this way and the number stays silently reusable. That is the case for `2026.1018` itself, which is one reason this PR opens the new scheme at `2026.1019` rather than trying to reissue it.

**`release.yml`** runs the gate before packaging, so a mismatched tag cannot produce a release at all. Prerelease detection moves off `contains(ref_name, '-b')` to a trailing beta-counter match, which handles the new format and still recognises the old one. `github.ref_name` is passed via `env` rather than interpolated into the shell.

### Why ordering is not computed with AwesomeVersion

The release job blocks all egress except GitHub, so it cannot `pip install awesomeversion` without widening its network access to validate a string. `verify-version` therefore orders versions from the version grammar instead, and `tests/test_version_scheme.py` is where that shortcut is justified: it asserts every version the scheme can produce is valid AwesomeVersion, is flagged as a pre-release when it should be, and orders identically under both comparators. Same coverage, no new egress on the release path.

`sort_key` lives in `update_version.py` next to the grammar it derives from, so the script and the tests share one definition.

## Testing

Verified against this repo's real tags:

```
2026.1018-b01   ->  rejected: not a valid version (with the AwesomeVersion reason)
2026.1019       ->  rejected: manifest.json and const.py do not match the tag
2026.1019.0b1   ->  rejected: not newer than existing release '2026.1019'
2026.1018       ->  Version OK
```

25 new tests, `ruff check`/`ruff format` clean, `release.yml` parses.

> [!NOTE]
> The release workflow only runs on tag push, so none of this is exercised by PR CI. Cutting a throwaway `2026.1019.0b1` would prove the gate end to end before a release that matters.

## Follow-up

This does not renumber anything by itself: the manifest still reads `2026.1018`. The first tag under the new scheme comes from the default path, no `--set` needed:

```bash
python3 update_version.py --beta      # 2026.1018 -> 2026.1019.0b1
```

`2026.1018` is deliberately skipped rather than reissued, since that number is now ambiguous in the wild.
