### PR TITLE
docs: contributing guide, plus release tooling fixes it turned up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: "Afvalwijzer: Release"
 on:
   push:
     tags:
-      - "*"
+      - "[0-9][0-9][0-9][0-9].[0-9]+"
+      - "[0-9][0-9][0-9][0-9].[0-9]+.0b[0-9]+"
 
 permissions:
   contents: write

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -125,7 +125,7 @@ voluptuous = "vol"
 
 [lint.isort]
 force-sort-within-sections = true
-known-first-party = ["homeassistant"]
+known-first-party = ["homeassistant", "version_scheme"]
 combine-as-imports = true
 
 [lint.flake8-pytest-style]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,8 +117,8 @@ so if you change the grammar, that is the test that will tell you.
    It prints `Version OK: <tag>` when the tag is well formed, matches both
    files, and is newer than every existing release tag.
 
-5. Tag and push. No `v` prefix: the workflow matches the tag against the version
-   grammar and compares it to the manifest verbatim, so a `v`-prefixed tag is
+5. Tag and push. The workflow matches the tag against the version
+   grammar and compares it to the manifest verbatim, so a malformed tag is
    silently ignored.
 
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,161 @@
+# Contributing
+
+Thanks for helping out. This document covers local development and, for
+maintainers, how to cut a release.
+
+For bug reports and feature requests, see [SUPPORT.md](.github/SUPPORT.md)
+instead.
+
+## Getting started
+
+```bash
+git clone https://github.com/xirixiz/homeassistant-afvalwijzer.git
+cd homeassistant-afvalwijzer
+python3 -m venv .venv
+source .venv/bin/activate
+scripts/setup
+```
+
+`scripts/setup` installs the system dependencies, `requirements.txt`, and the
+pre-commit hook. It does **not** install the test-only dependencies, so before
+running the suite:
+
+```bash
+python3 -m pip install -r requirements_test.txt
+```
+
+## Day-to-day scripts
+
+Everything you need is already in `scripts/`:
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/setup` | Install dependencies and the pre-commit hook |
+| `scripts/test` | Run the test suite (`pytest tests`) |
+| `scripts/coverage` | Tests plus coverage and `pytest.xml`, which is what CI runs |
+| `scripts/test-module` | Run a single module against the live providers |
+| `scripts/check-municipality-coverage` | Check which municipalities are covered |
+| `scripts/lint` | `ruff check . --fix` |
+| `scripts/develop` | `docker compose up` to run Home Assistant locally with the component mounted |
+| `scripts/upgrade` | Upgrade to the latest (pre-release) Home Assistant |
+| `scripts/dev-branch` | Install Home Assistant from its `dev` branch |
+| `scripts/specific-version` | Pin a specific Home Assistant version |
+
+`.pre-commit-config.yaml` runs ruff check and ruff format, and normalises JSON
+in `manifest.json`, `hacs.json`, `strings.json`, and the translation files. Hand
+edited JSON will be reformatted on commit, so let the hook win rather than
+fighting it.
+
+## What CI enforces
+
+`.github/workflows/ci.yml` runs on every pull request, on pushes to `main`, and
+on tags:
+
+- hassfest and the HACS action (`category: integration`)
+- `ruff check`
+- `scripts/coverage`
+
+## Versioning scheme
+
+Versions are CalVer with a sequence number:
+
+- stable: `YYYY.SEQ`, for example `2026.1019`
+- beta: `YYYY.SEQ.0bN`, for example `2026.1019.0b1`
+
+The sequence starts at `1000` each calendar year and only ever increases within
+that year. The grammar lives in `VERSION_RE` in `update_version.py`.
+
+The `.0b` spelling is load bearing. Home Assistant and HACS compare versions
+with AwesomeVersion, which rejects the retired `2026.1019-b01` form outright and
+parses `2026.1019b1` without recognising it as a pre-release. Only `.0bN` is
+both parseable and correctly flagged as a beta.
+
+Ordering rule worth internalising: **a beta sorts below its own stable
+release.** Once `2026.1019` has shipped, `2026.1019.0b2` is in the past and can
+never be released. If you need another beta after a stable, open the next
+sequence.
+
+`tests/test_version_scheme.py` cross-checks this scheme against AwesomeVersion,
+so if you change the grammar, that is the test that will tell you.
+
+## Cutting a release (maintainers)
+
+1. Make sure `main` is green and up to date.
+
+2. Bump the version:
+
+   ```bash
+   python3 update_version.py --beta          # next beta
+   python3 update_version.py                 # next stable
+   python3 update_version.py --set 2026.1020 # explicit version
+   ```
+
+   A stable bump *promotes* an in-progress beta to its final version rather than
+   skipping a sequence: with `2026.1019.0b3` in the manifest, a plain
+   `update_version.py` produces `2026.1019`.
+
+   This rewrites both `custom_components/afvalwijzer/manifest.json` and
+   `custom_components/afvalwijzer/const/const.py`. Both must carry the version,
+   which is why the script is the only sanctioned way to bump.
+
+3. Commit both files. The existing convention is:
+
+   ```bash
+   git commit -am "Prepare release 2026.1019.0b1"
+   ```
+
+4. Dry-run the release gate locally before pushing anything:
+
+   ```bash
+   scripts/verify-version 2026.1019.0b1
+   ```
+
+   It prints `Version OK: <tag>` when the tag is well formed, matches both
+   files, and is newer than every existing release tag.
+
+5. Tag and push. No `v` prefix: the workflow matches the tag against the version
+   grammar and compares it to the manifest verbatim, so a `v`-prefixed tag is
+   silently ignored.
+
+   ```bash
+   git push origin main
+   git tag 2026.1019.0b1
+   git push origin 2026.1019.0b1
+   ```
+
+6. `.github/workflows/release.yml` takes over: it re-runs
+   `scripts/verify-version`, zips `custom_components/afvalwijzer` into
+   `afvalwijzer.zip`, and publishes a GitHub release with generated notes.
+   A tag ending in `bN` is published as a pre-release, everything else as a
+   stable release.
+
+The workflow only triggers on tags matching the version grammar, so unrelated
+tags are ignored rather than starting a release attempt. The flip side is that a
+malformed tag does nothing at all: if you push `v2026.1020` or `2026.1020-b01`
+and no workflow run appears, the tag name is why. Check the tag before assuming
+the release is queued.
+
+### When a release fails verification
+
+`scripts/verify-version` refuses to release rather than publishing something
+broken. It reports one of:
+
+- the tag is not a valid version
+- `manifest.json` or `const.py` does not match the tag
+- the tag is not newer than an existing release
+
+To recover, delete the tag and retag after fixing the version:
+
+```bash
+git push --delete origin 2026.1019.0b1
+git tag -d 2026.1019.0b1
+python3 update_version.py --set <correct version>
+git commit -am "Prepare release <correct version>"
+git push origin main
+git tag <correct version>
+git push origin <correct version>
+```
+
+Recreating the *same* tag after a fix is fine: the check excludes the tag being
+released from the "is it newer" comparison. Tags from older schemes (`5.3.3`,
+the retired `-bNN` betas) do not parse and are skipped entirely.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ Everything you need is already in `scripts/`:
 | `scripts/upgrade` | Upgrade to the latest (pre-release) Home Assistant |
 | `scripts/dev-branch` | Install Home Assistant from its `dev` branch |
 | `scripts/specific-version` | Pin a specific Home Assistant version |
+| `scripts/update-version` | Bump the version, see [Cutting a release](#cutting-a-release-maintainers) |
+| `scripts/verify-version` | Check a tag is releasable, see [Cutting a release](#cutting-a-release-maintainers) |
 
 `.pre-commit-config.yaml` runs ruff check and ruff format, and normalises JSON
 in `manifest.json`, `hacs.json`, `strings.json`, and the translation files. Hand
@@ -65,7 +67,7 @@ Versions are CalVer with a sequence number:
 - beta: `YYYY.SEQ.0bN`, for example `2026.1019.0b1`
 
 The sequence starts at `1000` each calendar year and only ever increases within
-that year. The grammar lives in `VERSION_RE` in `update_version.py`.
+that year. The grammar lives in `VERSION_RE` in `scripts/version_scheme.py`.
 
 The `.0b` spelling is load bearing. Home Assistant and HACS compare versions
 with AwesomeVersion, which rejects the retired `2026.1019-b01` form outright and
@@ -87,14 +89,14 @@ so if you change the grammar, that is the test that will tell you.
 2. Bump the version:
 
    ```bash
-   python3 update_version.py --beta          # next beta
-   python3 update_version.py                 # next stable
-   python3 update_version.py --set 2026.1020 # explicit version
+   scripts/update-version --beta          # next beta
+   scripts/update-version                 # next stable
+   scripts/update-version --set 2026.1020 # explicit version
    ```
 
    A stable bump *promotes* an in-progress beta to its final version rather than
    skipping a sequence: with `2026.1019.0b3` in the manifest, a plain
-   `update_version.py` produces `2026.1019`.
+   `scripts/update-version` produces `2026.1019`.
 
    This rewrites both `custom_components/afvalwijzer/manifest.json` and
    `custom_components/afvalwijzer/const/const.py`. Both must carry the version,
@@ -151,7 +153,7 @@ To recover, delete the tag and retag after fixing the version:
 ```bash
 git push --delete origin 2026.1019.0b1
 git tag -d 2026.1019.0b1
-python3 update_version.py --set <correct version>
+scripts/update-version --set <correct version>
 git commit -am "Prepare release <correct version>"
 git push origin main
 git tag <correct version>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,21 +8,31 @@ instead.
 
 ## Getting started
 
+### Dev container (recommended)
+
+Open the repository in VS Code and reopen in the container. `scripts/setup` runs
+automatically as `postCreateCommand` and you are done.
+
+### Local checkout
+
 ```bash
 git clone https://github.com/xirixiz/homeassistant-afvalwijzer.git
 cd homeassistant-afvalwijzer
 python3 -m venv .venv
 source .venv/bin/activate
-scripts/setup
+python3 -m pip install -r requirements.txt -r requirements_test.txt
+pre-commit install
 ```
 
-`scripts/setup` installs the system dependencies, `requirements.txt`, and the
-pre-commit hook. It does **not** install the test-only dependencies, so before
-running the suite:
+This is the same set of Python packages CI installs, and it is enough to run the
+test suite.
 
-```bash
-python3 -m pip install -r requirements_test.txt
-```
+Do **not** run `scripts/setup` on your own machine. It is the dev container
+bootstrap: it calls `sudo apt-get install` for `libpcap-dev` and
+`libturbojpeg0`, which are Home Assistant core build dependencies this
+integration does not need, and it installs into whatever Python happens to be
+active rather than a virtualenv. That is fine inside a disposable container on
+Debian, and intrusive or simply broken anywhere else.
 
 ## Day-to-day scripts
 
@@ -30,7 +40,7 @@ Everything you need is already in `scripts/`:
 
 | Script | Purpose |
 | --- | --- |
-| `scripts/setup` | Install dependencies and the pre-commit hook |
+| `scripts/setup` | Dev container bootstrap only, see above |
 | `scripts/test` | Run the test suite (`pytest tests`) |
 | `scripts/coverage` | Tests plus coverage and `pytest.xml`, which is what CI runs |
 | `scripts/test-module` | Run a single module against the live providers |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ instead.
 
 ### Dev container (recommended)
 
-Open the repository in VS Code and reopen in the container. `scripts/setup` runs
-automatically as `postCreateCommand` and you are done.
+Open the repository in VS Code and reopen in the container. Setup runs
+automatically and you are done.
 
 ### Local checkout
 
@@ -27,20 +27,12 @@ pre-commit install
 This is the same set of Python packages CI installs, and it is enough to run the
 test suite.
 
-Do **not** run `scripts/setup` on your own machine. It is the dev container
-bootstrap: it calls `sudo apt-get install` for `libpcap-dev` and
-`libturbojpeg0`, which are Home Assistant core build dependencies this
-integration does not need, and it installs into whatever Python happens to be
-active rather than a virtualenv. That is fine inside a disposable container on
-Debian, and intrusive or simply broken anywhere else.
-
 ## Day-to-day scripts
 
 Everything you need is already in `scripts/`:
 
 | Script | Purpose |
 | --- | --- |
-| `scripts/setup` | Dev container bootstrap only, see above |
 | `scripts/test` | Run the test suite (`pytest tests`) |
 | `scripts/coverage` | Tests plus coverage and `pytest.xml`, which is what CI runs |
 | `scripts/test-module` | Run a single module against the live providers |

--- a/README.md
+++ b/README.md
@@ -325,6 +325,15 @@ sort:
   reverse: false
 ```
 
+## Contributing
+
+Bug reports and feature requests: please read [SUPPORT.md](.github/SUPPORT.md) first.
+
+For local development, the helper scripts, and the release process, see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
 ## Installation
 
 ### Manual Installation

--- a/scripts/update-version
+++ b/scripts/update-version
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Update version numbers in manifest.json and const.py.
+
+With no arguments this computes the next stable release. The version grammar
+and ordering live in version_scheme.py, which scripts/verify-version imports
+too so that the two can never disagree.
+"""
+
+import argparse
+import logging
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from version_scheme import (  # noqa: E402
+    VERSION_RE,
+    compute_next_version,
+    current_version,
+    write_version,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+LOGGER = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Update version numbers in manifest.json and const.py."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--beta",
+        action="store_true",
+        help="cut a beta (YYYY.SEQ.0bN) instead of a stable release",
+    )
+    group.add_argument(
+        "--set",
+        dest="explicit",
+        metavar="VERSION",
+        help="set an explicit version instead of computing the next one",
+    )
+    args = parser.parse_args()
+
+    if args.explicit:
+        if not VERSION_RE.match(args.explicit.strip()):
+            parser.error(
+                f"Invalid version {args.explicit!r}; expected YYYY.SEQ or YYYY.SEQ.0bN"
+            )
+        new_version = args.explicit.strip()
+    else:
+        new_version = compute_next_version(current_version(), beta=args.beta)
+
+    old_version = write_version(new_version)
+
+    LOGGER.info("Updated version from %s to %s", old_version, new_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-version
+++ b/scripts/verify-version
@@ -14,18 +14,19 @@ cross-checks that the two agree.
 
 import json
 import pathlib
-import re
 import subprocess
 import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from update_version import VERSION_RE, sort_key  # noqa: E402
-
-MANIFEST_PATH = REPO_ROOT / "custom_components/afvalwijzer/manifest.json"
-CONST_PATH = REPO_ROOT / "custom_components/afvalwijzer/const/const.py"
-CONST_VERSION_RE = re.compile(r'VERSION\s*=\s*"(?P<version>[^"]+)"')
+from update_version import (  # noqa: E402
+    CONST_PATH,
+    MANIFEST_PATH,
+    VERSION_ASSIGN_RE,
+    VERSION_RE,
+    sort_key,
+)
 
 
 def _manifest_version() -> str:
@@ -33,7 +34,7 @@ def _manifest_version() -> str:
 
 
 def _const_version() -> str:
-    match = CONST_VERSION_RE.search(CONST_PATH.read_text(encoding="utf-8"))
+    match = VERSION_ASSIGN_RE.search(CONST_PATH.read_text(encoding="utf-8"))
     return match.group("version") if match else ""
 
 

--- a/scripts/verify-version
+++ b/scripts/verify-version
@@ -18,9 +18,9 @@ import subprocess
 import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
-from update_version import (  # noqa: E402
+from version_scheme import (  # noqa: E402
     CONST_PATH,
     MANIFEST_PATH,
     VERSION_ASSIGN_RE,
@@ -96,7 +96,7 @@ def main() -> int:
         for error in errors:
             print(f"{tag}: {error}", file=sys.stderr)
         print(
-            "Refusing to release: run 'python3 update_version.py' and retag.",
+            "Refusing to release: run 'scripts/update-version' and retag.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/version_scheme.py
+++ b/scripts/version_scheme.py
@@ -1,17 +1,16 @@
-#!/usr/bin/env python3
-"""Afvalwijzer integration."""
+"""The Afvalwijzer release version scheme.
 
-import argparse
+The grammar, ordering and file-writing shared by `scripts/update-version` and
+`scripts/verify-version`. This is a module rather than an executable because
+both of those import it, as does tests/test_version_scheme.py.
+"""
+
 from datetime import date
 import json
-import logging
 from pathlib import Path
 import re
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
-LOGGER = logging.getLogger(__name__)
-
-REPO_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_PATH = REPO_ROOT / "custom_components/afvalwijzer/manifest.json"
 CONST_PATH = REPO_ROOT / "custom_components/afvalwijzer/const/const.py"
 
@@ -85,7 +84,13 @@ def compute_next_version(current_version: str | None, *, beta: bool = False) -> 
     return f"{current_year}.{seq + 1}"
 
 
-def _write_version(new_version: str) -> str | None:
+def current_version() -> str | None:
+    """Return the version currently recorded in the manifest, if any."""
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return str(manifest.get("version", "")).strip() or None
+
+
+def write_version(new_version: str) -> str | None:
     """Write `new_version` to the manifest and const module, returning the old one."""
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
     old_version = str(manifest.get("version", "")).strip() or None
@@ -108,40 +113,3 @@ def _write_version(new_version: str) -> str | None:
         CONST_PATH.write_text(new_const_text, encoding="utf-8")
 
     return old_version
-
-
-def main() -> None:
-    """Update version numbers in manifest.json and const.py."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        "--beta",
-        action="store_true",
-        help="cut a beta (YYYY.SEQ.0bN) instead of a stable release",
-    )
-    group.add_argument(
-        "--set",
-        dest="explicit",
-        metavar="VERSION",
-        help="set an explicit version instead of computing the next one",
-    )
-    args = parser.parse_args()
-
-    if args.explicit:
-        if not VERSION_RE.match(args.explicit.strip()):
-            parser.error(
-                f"Invalid version {args.explicit!r}; expected YYYY.SEQ or YYYY.SEQ.0bN"
-            )
-        new_version = args.explicit.strip()
-    else:
-        manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
-        current = str(manifest.get("version", "")).strip() or None
-        new_version = compute_next_version(current, beta=args.beta)
-
-    old_version = _write_version(new_version)
-
-    LOGGER.info("Updated version from %s to %s", old_version, new_version)
-
-
-if __name__ == "__main__":
-    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,12 @@ except Exception:
 # Set environment variable to skip runtime setup during tests
 os.environ["AFVALWIJZER_SKIP_INIT"] = "1"
 
-# Add the repository root to the path so `custom_components` is importable
+# Add scripts/ to the path so the release tooling (version_scheme) is importable.
+# The repository root itself is already on sys.path: tests/ is a package, so
+# pytest prepends the first non-package parent. scripts/ is not a package, so it
+# has to be added by hand.
 repo_root = Path(__file__).parent.parent
-sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(repo_root / "scripts"))
 
 
 @pytest.fixture

--- a/tests/test_version_scheme.py
+++ b/tests/test_version_scheme.py
@@ -10,7 +10,7 @@ orders the same way under both comparators.
 from awesomeversion import AwesomeVersion
 import pytest
 
-from update_version import compute_next_version, sort_key
+from version_scheme import compute_next_version, sort_key
 
 # Ascending order, mixing betas and stables across sequences and years.
 _ASCENDING = [
@@ -71,6 +71,6 @@ def test_retired_beta_suffix_is_rejected():
     ],
 )
 def test_computed_versions_move_forward(current, beta, expected):
-    """Each step update_version.py can take is an increase, never a downgrade."""
+    """Each step scripts/update-version can take is an increase, never a downgrade."""
     assert compute_next_version(current, beta=beta) == expected
     assert sort_key(current) < sort_key(expected)

--- a/update_version.py
+++ b/update_version.py
@@ -11,8 +11,9 @@ import re
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 LOGGER = logging.getLogger(__name__)
 
-MANIFEST_PATH = Path("custom_components/afvalwijzer/manifest.json")
-CONST_PATH = Path("custom_components/afvalwijzer/const/const.py")
+REPO_ROOT = Path(__file__).resolve().parent
+MANIFEST_PATH = REPO_ROOT / "custom_components/afvalwijzer/manifest.json"
+CONST_PATH = REPO_ROOT / "custom_components/afvalwijzer/const/const.py"
 
 # YYYY.SEQ for a stable release, YYYY.SEQ.0bN for a beta. The ".0b" form is
 # what AwesomeVersion (used by HA and HACS) parses as a CalVer pre-release:


### PR DESCRIPTION
## What

Documents the release process, and fixes three things writing it down exposed.

## Why

The release process was only discoverable by reading `update_version.py`, `scripts/verify-version` and `.github/workflows/release.yml`. Nothing recorded that:

- versions are `YYYY.SEQ` / `YYYY.SEQ.0bN`, and the `.0b` spelling is load bearing (AwesomeVersion rejects `2026.1019-b01` and does not treat `2026.1019b1` as a pre-release)
- `manifest.json` and `const.py` must both match the tag, so the bump script is the only sanctioned way to do it
- a beta sorts *below* its own stable release, so a shipped sequence can never be re-opened as a beta
- `scripts/verify-version <tag>` can be run locally as a dry run before tagging

## Changes

**`CONTRIBUTING.md`** (new) - setup, the `scripts/` helpers, what CI enforces, the versioning scheme, the six release steps, and how to recover from a rejected tag. Lands here rather than in the README, which is end-user facing; the README gets a short pointer.

**`.github/workflows/release.yml`** - the trigger was `tags: "*"`, so any pushed tag started a release attempt that `verify-version` then had to reject:

```yaml
tags:
  - "[0-9][0-9][0-9][0-9].[0-9]+"
  - "[0-9][0-9][0-9][0-9].[0-9]+.0b[0-9]+"
```

Tradeoff: junk tags no longer start a failing job, but a *typo'd* release tag now does nothing silently instead of failing loudly. `verify-version` still runs on every tag that matches, so the manifest-mismatch and not-newer checks are unaffected. Called out in the release section of the guide.

**`update_version.py` path fix** - it resolved `manifest.json` and `const.py` against the current working directory, so it only worked from the repo root and died with `FileNotFoundError` anywhere else. Now anchored on the module's own location, matching what `verify-version` already did.

**`update_version.py` to `scripts/update-version`** - moves the release tooling in with everything else. A straight rename was impossible: the module is imported by `scripts/verify-version` and `tests/test_version_scheme.py`, and a hyphenated extension-less file cannot be imported. So it splits into `scripts/version_scheme.py` (grammar, ordering, file writing - imported by both) and `scripts/update-version` (the CLI, named like its neighbours). Shared constants now live in one place instead of being duplicated across the two.

`tests/conftest.py` gains `scripts/` on `sys.path`, and loses the repo-root insert next to it: `tests/` is a package, so pytest already prepends the root. `.ruff.toml` gains `version_scheme` as first-party so isort keeps the grouping right.

## Verification

- `scripts/update-version` and `scripts/verify-version` both work from the repo root, from `scripts/`, and from `/tmp` via absolute path
- negative paths still fail correctly: manifest mismatch, and the retired `2026.1019-b01` form
- release path is stdlib-only and runs under bare `/usr/bin/python3`, which matters because `release.yml` blocks egress to PyPI
- tag globs translated to regex per GitHub's filter-pattern semantics and tested: matches `2026.1019`, `2026.1019.0b12`, `2027.1000.0b3`; rejects `test`, `v2026.1019`, `2026.1019-b01`, `2026.1019b1`, `2026.1019.1`, and the retired `5.x` tags
- repo-root insert removal verified by probe (pytest puts the root at `sys.path[0]` itself) and by an unchanged full-suite result
- `custom_components/` untouched; `scripts/update-version` committed as `100755`

## Note

The tag-trigger change is the one thing CI cannot exercise - it only takes effect on a tag push. First real test is the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
