### PR TITLE
docs(readme): stop the notification example re-notifying on reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,11 +504,13 @@ description: "Notify the latest waste collector message to mobile app"
 triggers:
   - trigger: state
     entity_id: sensor.afvalwijzer_notifications
-    from: null
-    to: null
+    not_from:
+      - unknown
+      - unavailable
 conditions:
-  - condition: template
-    value_template: "{{ states('sensor.afvalwijzer_notifications') | int > 0 }}"
+  - condition: numeric_state
+    entity_id: sensor.afvalwijzer_notifications
+    above: 0
 actions:
   - action: notify.mobile_app
     data:
@@ -517,6 +519,10 @@ actions:
         {% set notifs = state_attr('sensor.afvalwijzer_notifications',
         'notifications') %} {{ notifs[-1].content }}
 ```
+
+> The `not_from` guard matters: reloading the integration briefly sets the sensor to
+> `unavailable`, so a trigger without it fires again when the sensor comes back and
+> re-sends a message you have already seen.
 
 ---
 


### PR DESCRIPTION
## What

Fixes the `WASTE COLLECTOR MESSAGES - AUTOMATION` example in the README, which re-sends a notification every time the integration reloads.

## Why

Found while debugging a live instance. The example triggered on *any* state change:

```yaml
triggers:
  - trigger: state
    entity_id: sensor.afvalwijzer_notifications
    from: null
    to: null
```

Reloading the config entry (every options change does this) takes every entity of the entry through `unavailable` and back. The logbook on the affected instance shows the pattern on each reload:

```
17:36:06.314  unavailable
17:36:06.447  1
17:38:04.924  unavailable
17:38:05.062  1
```

The trigger fires on both legs, and the second one passes the condition because the count genuinely is `1`. The message is not new; it is the same one being re-announced. Automation traces confirm the pair: `failed_conditions` on the `unavailable` leg, `finished` on the restore.

The condition had a separate defect. `| int` with no default does not evaluate false on a non-numeric state, it raises:

```
ValueError: int got invalid input 'unavailable' when rendering or compiling template
```

So the example also logs a template error on every reload.

## Changes

```yaml
triggers:
  - trigger: state
    entity_id: sensor.afvalwijzer_notifications
    not_from:
      - unknown
      - unavailable
conditions:
  - condition: numeric_state
    entity_id: sensor.afvalwijzer_notifications
    above: 0
```

`numeric_state` is validated at config load rather than failing at runtime, and it evaluates false on `unavailable` instead of raising. Added a short note under the block so readers understand the guard rather than just copying it.

## Verification

- Both blocks extracted from the README and validated against the real HA schemas (`TRIGGER_STATE_SCHEMA`, `CONDITION_SCHEMA`) rather than eyeballed
- `| int` vs `| int(0)` behaviour on `'unavailable'` confirmed against the installed `forgiving_int_filter`
- Checked the rest of the README: this was the only `from: null` / `to: null` trigger and the only bare `| int`
- Same change applied to the live automation it came from; no re-notify since

## Note

Nothing in the integration is at fault here. The `unavailable` transition is core config-entry unload behaviour, identical for every integration; the example just needed the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
